### PR TITLE
Make host and database configuration keys required

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -22,8 +22,8 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
-                ->scalarNode('host')->end()
-                ->scalarNode('database')->end()
+                ->scalarNode('host')->isRequired()->end()
+                ->scalarNode('database')->isRequired()->end()
                 ->scalarNode('udp_port')->defaultValue('4444')->end()
                 ->scalarNode('http_port')->defaultValue('8086')->end()
                 ->scalarNode('username')->defaultValue('')->end()

--- a/tests/unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/unit/DependencyInjection/ConfigurationTest.php
@@ -21,7 +21,10 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
 
         $processor = new Processor();
 
-        $conf = $processor->process($builtConf, []);
+        $conf = $processor->process($builtConf, ['influx_db' => [
+            'host' => '127.0.0.1',
+            'database' => 'telegraf',
+        ]]);
 
         $this->assertArrayHasKey('udp_port', $conf);
         $this->assertArrayHasKey('http_port', $conf);


### PR DESCRIPTION
Those keys are needed to get your bundle work, but it's not specify on the `Configuration` class.

This PR solve this issue.

This will avoid hard to understand error like this:

``` bash
  [Symfony\Component\Debug\Exception\ContextErrorException]  
  Notice: Undefined index: host                              


Script Sensio\Bundle\DistributionBundle\Composer\ScriptHandler::clearCache handling the post-install-cmd event terminated with an exception


  [RuntimeException]                                                         
  An error occurred when executing the "'cache:clear --no-warmup'" command:  

    [Symfony\Component\Debug\Exception\ContextErrorException]                
    Notice: Undefined index: host                                            
```

Now you will have this instead:

``` bash
  [Symfony\Component\Config\Definition\Exception\InvalidConfigurationException]  
  The child node "host" at path "influx_db" must be configured.                  
```

Much clearer, isn't it? :wink: 
