### PR TITLE
Integrate StyleCI configuration and PHP-CS-Fixer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /composer.lock
 /vendor/
 /bin/
+/.php_cs.cache

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,9 @@
+<?php
+
+require_once __DIR__.'/vendor/sllh/php-cs-fixer-styleci-bridge/autoload.php';
+
+use SLLH\StyleCIBridge\ConfigBridge;
+
+return ConfigBridge::create()
+    ->setUsingCache(true)
+;

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,0 +1,6 @@
+preset: symfony
+
+enabled:
+  - newline_after_open_tag
+  - ordered_use
+  - short_array_syntax

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^5.1",
-        "phpspec/prophecy": "^1.6.0"
+        "phpspec/prophecy": "^1.6.0",
+        "sllh/php-cs-fixer-styleci-bridge": "^2.0"
     },
     "license": "MIT",
     "authors": [

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -33,6 +33,4 @@ class Configuration implements ConfigurationInterface
 
         return $treeBuilder;
     }
-
 }
-

--- a/src/DependencyInjection/InfluxDbExtension.php
+++ b/src/DependencyInjection/InfluxDbExtension.php
@@ -29,7 +29,7 @@ class InfluxDbExtension extends Extension
         $container->setParameter('influx_db.username', $config['username']);
         $container->setParameter('influx_db.password', $config['password']);
 
-        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
 
         if ($config['use_events'] === true) {
@@ -38,5 +38,4 @@ class InfluxDbExtension extends Extension
 
         return $config;
     }
-
 }

--- a/src/Events/DeferredHttpEvent.php
+++ b/src/Events/DeferredHttpEvent.php
@@ -1,20 +1,19 @@
 <?php
+
 declare(strict_types=1);
+
 namespace Algatux\InfluxDbBundle\Events;
 
 use Algatux\InfluxDbBundle\Model\PointsCollection;
 use Algatux\InfluxDbBundle\Services\Clients\Contracts\ClientInterface;
 
 /**
- * Class DeferredHttpEvent
- * @package Algatux\InfluxDbBundle\Events
+ * Class DeferredHttpEvent.
  */
 class DeferredHttpEvent extends DeferredInfluxDbEvent
 {
-
     public function __construct(PointsCollection $collection)
     {
         parent::__construct($collection, ClientInterface::HTTP_CLIENT);
     }
-
 }

--- a/src/Events/DeferredInfluxDbEvent.php
+++ b/src/Events/DeferredInfluxDbEvent.php
@@ -3,8 +3,7 @@
 namespace Algatux\InfluxDbBundle\Events;
 
 /**
- * Class DeferredInfluxDbEvent
- * @package Algatux\InfluxDbBundle\Events
+ * Class DeferredInfluxDbEvent.
  */
 abstract class DeferredInfluxDbEvent extends InfluxDbEvent
 {

--- a/src/Events/DeferredUdpEvent.php
+++ b/src/Events/DeferredUdpEvent.php
@@ -1,20 +1,19 @@
 <?php
+
 declare(strict_types=1);
+
 namespace Algatux\InfluxDbBundle\Events;
 
 use Algatux\InfluxDbBundle\Model\PointsCollection;
 use Algatux\InfluxDbBundle\Services\Clients\Contracts\ClientInterface;
 
 /**
- * Class DeferredUdpEvent
- * @package Algatux\InfluxDbBundle\Events
+ * Class DeferredUdpEvent.
  */
 class DeferredUdpEvent extends DeferredInfluxDbEvent
 {
-
     public function __construct(PointsCollection $collection)
     {
         parent::__construct($collection, ClientInterface::UDP_CLIENT);
     }
-
 }

--- a/src/Events/HttpEvent.php
+++ b/src/Events/HttpEvent.php
@@ -1,20 +1,19 @@
 <?php
+
 declare(strict_types=1);
+
 namespace Algatux\InfluxDbBundle\Events;
 
 use Algatux\InfluxDbBundle\Model\PointsCollection;
 use Algatux\InfluxDbBundle\Services\Clients\Contracts\ClientInterface;
 
 /**
- * Class HttpEvent
- * @package Algatux\InfluxDbBundle\Events
+ * Class HttpEvent.
  */
 class HttpEvent extends InfluxDbEvent
 {
-
     public function __construct(PointsCollection $collection)
     {
         parent::__construct($collection, ClientInterface::HTTP_CLIENT);
     }
-
 }

--- a/src/Events/InfluxDbEvent.php
+++ b/src/Events/InfluxDbEvent.php
@@ -1,5 +1,7 @@
 <?php
+
 declare(strict_types=1);
+
 namespace Algatux\InfluxDbBundle\Events;
 
 use Algatux\InfluxDbBundle\Model\PointsCollection;
@@ -7,24 +9,23 @@ use Algatux\InfluxDbBundle\Services\Clients\Contracts\ClientInterface;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
- * Class InfluxDbEvent
- * @package Algatux\InfluxDbBundle\Events
+ * Class InfluxDbEvent.
  */
 abstract class InfluxDbEvent extends Event
 {
-
     const NAME = 'influxdb.points_collected';
 
-    /** @var string  */
+    /** @var string */
     protected $writeMode;
 
-    /** @var PointsCollection  */
+    /** @var PointsCollection */
     protected $points;
 
     /**
      * InfluxDbEvent constructor.
+     *
      * @param PointsCollection $collection
-     * @param string $writeMode
+     * @param string           $writeMode
      */
     public function __construct(PointsCollection $collection, string $writeMode = ClientInterface::UDP_CLIENT)
     {
@@ -47,5 +48,4 @@ abstract class InfluxDbEvent extends Event
     {
         return $this->points;
     }
-
 }

--- a/src/Events/Listeners/InfluxDbEventListener.php
+++ b/src/Events/Listeners/InfluxDbEventListener.php
@@ -1,6 +1,9 @@
 <?php
+
 declare(strict_types=1);
+
 namespace Algatux\InfluxDbBundle\Events\Listeners;
+
 use Algatux\InfluxDbBundle\Events\DeferredInfluxDbEvent;
 use Algatux\InfluxDbBundle\Events\InfluxDbEvent;
 use Algatux\InfluxDbBundle\Model\PointsCollection;
@@ -10,33 +13,31 @@ use Algatux\InfluxDbBundle\Services\PointsCollectionStorage;
 use Symfony\Component\EventDispatcher\Event;
 
 /**
- * Class InfluxDbEventListener
- * @package Algatux\InfluxDbBundle\Events\Listeners
+ * Class InfluxDbEventListener.
  */
 class InfluxDbEventListener
 {
-
-    /** @var WriterClient  */
+    /** @var WriterClient */
     private $httpWriter;
 
-    /** @var WriterClient  */
+    /** @var WriterClient */
     private $udpWriter;
 
-    /** @var PointsCollectionStorage  */
+    /** @var PointsCollectionStorage */
     private $collectionStorage;
 
     /**
      * InfluxDbEventListener constructor.
-     * @param WriterClient $httpWriter
-     * @param WriterClient $udpWriter
+     *
+     * @param WriterClient            $httpWriter
+     * @param WriterClient            $udpWriter
      * @param PointsCollectionStorage $collectionStorage
      */
     public function __construct(
         WriterClient $httpWriter,
         WriterClient $udpWriter,
         PointsCollectionStorage $collectionStorage
-    )
-    {
+    ) {
         $this->httpWriter = $httpWriter;
         $this->udpWriter = $udpWriter;
         $this->collectionStorage = $collectionStorage;
@@ -47,7 +48,6 @@ class InfluxDbEventListener
         $points = $event->getPoints();
 
         if ($event instanceof DeferredInfluxDbEvent) {
-
             $this->collectionStorage->storeCollection($points, $event->getWriteMode());
 
             return true;
@@ -60,6 +60,7 @@ class InfluxDbEventListener
 
     /**
      * @param Event $event
+     *
      * @return bool
      */
     public function onKernelTerminate(Event $event): bool
@@ -77,7 +78,7 @@ class InfluxDbEventListener
     }
 
     /**
-     * @param string $writemode
+     * @param string           $writemode
      * @param PointsCollection $points
      */
     private function writePoints(string $writemode, PointsCollection $points)
@@ -90,7 +91,4 @@ class InfluxDbEventListener
             $this->httpWriter->write($points);
         }
     }
-
-
-
 }

--- a/src/Events/UdpEvent.php
+++ b/src/Events/UdpEvent.php
@@ -1,20 +1,19 @@
 <?php
+
 declare(strict_types=1);
+
 namespace Algatux\InfluxDbBundle\Events;
 
 use Algatux\InfluxDbBundle\Model\PointsCollection;
 use Algatux\InfluxDbBundle\Services\Clients\Contracts\ClientInterface;
 
 /**
- * Class UdpEvent
- * @package Algatux\InfluxDbBundle\Events
+ * Class UdpEvent.
  */
 class UdpEvent extends InfluxDbEvent
 {
-
     public function __construct(PointsCollection $collection)
     {
         parent::__construct($collection, ClientInterface::UDP_CLIENT);
     }
-
 }

--- a/src/InfluxDbBundle.php
+++ b/src/InfluxDbBundle.php
@@ -7,10 +7,8 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class InfluxDbBundle extends Bundle
 {
-
     public function getContainerExtension()
     {
         return new InfluxDbExtension();
     }
-
 }

--- a/src/Model/PointsCollection.php
+++ b/src/Model/PointsCollection.php
@@ -1,26 +1,26 @@
 <?php
+
 declare(strict_types=1);
+
 namespace Algatux\InfluxDbBundle\Model;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use InfluxDB\Database;
 
 /**
- * Class PointsCollection
- * @package Algatux\InfluxDbBundle\Model
+ * Class PointsCollection.
  */
 class PointsCollection extends ArrayCollection
 {
-
     public $precision;
 
     /**
      * Initializes a new ArrayCollection.
      *
-     * @param array $elements
+     * @param array  $elements
      * @param string $precision
      */
-    public function __construct(array $elements = array(), string $precision = Database::PRECISION_SECONDS)
+    public function __construct(array $elements = [], string $precision = Database::PRECISION_SECONDS)
     {
         parent::__construct($elements);
         $this->precision = $precision;
@@ -33,5 +33,4 @@ class PointsCollection extends ArrayCollection
     {
         return $this->precision;
     }
-
 }

--- a/src/Services/Clients/Contracts/ClientInterface.php
+++ b/src/Services/Clients/Contracts/ClientInterface.php
@@ -1,16 +1,15 @@
 <?php
+
 declare(strict_types=1);
+
 namespace Algatux\InfluxDbBundle\Services\Clients\Contracts;
 
 /**
- * Interface ClientInterface
- * @package Algatux\InfluxDbBundle\Clients
+ * Interface ClientInterface.
  */
 interface ClientInterface
 {
-
     const HTTP_CLIENT = 'http';
 
     const UDP_CLIENT = 'udp';
-
 }

--- a/src/Services/Clients/Contracts/ReaderInterface.php
+++ b/src/Services/Clients/Contracts/ReaderInterface.php
@@ -1,10 +1,11 @@
 <?php
+
 declare(strict_types=1);
+
 namespace Algatux\InfluxDbBundle\Services\Clients\Contracts;
 
 /**
- * Interface ReaderInterface
- * @package Algatux\InfluxDbBundle\Services\Clients\Contracts
+ * Interface ReaderInterface.
  */
 interface ReaderInterface
 {

--- a/src/Services/Clients/Contracts/WriterInterface.php
+++ b/src/Services/Clients/Contracts/WriterInterface.php
@@ -1,19 +1,20 @@
 <?php
+
 declare(strict_types=1);
+
 namespace Algatux\InfluxDbBundle\Services\Clients\Contracts;
+
 use Algatux\InfluxDbBundle\Model\PointsCollection;
 
 /**
- * Interface WriterInterface
- * @package Algatux\InfluxDbBundle\Services\Clients\Contracts
+ * Interface WriterInterface.
  */
 interface WriterInterface
 {
-
     /**
      * @param PointsCollection $points
+     *
      * @return bool
      */
     public function write(PointsCollection $points): bool;
-
 }

--- a/src/Services/Clients/InfluxDbClientFactory.php
+++ b/src/Services/Clients/InfluxDbClientFactory.php
@@ -1,5 +1,7 @@
 <?php
-declare(strict_types = 1);
+
+declare(strict_types=1);
+
 namespace Algatux\InfluxDbBundle\Services\Clients;
 
 use InfluxDB\Client;
@@ -7,32 +9,31 @@ use InfluxDB\Database;
 use InfluxDB\Driver\UDP;
 
 /**
- * Class InfluxDbClientFactory
- * @package Algatux\InfluxDbBundle\Services\Clients
+ * Class InfluxDbClientFactory.
  */
 class InfluxDbClientFactory
 {
-
-    /** @var string  */
+    /** @var string */
     private $host;
 
-    /** @var string  */
+    /** @var string */
     private $udpPort;
 
-    /** @var string  */
+    /** @var string */
     private $httpPort;
 
-    /** @var string  */
+    /** @var string */
     private $database;
 
     /** @var string */
     private $username;
 
-    /** @var string  */
+    /** @var string */
     private $password;
 
     /**
      * InfluxDbClientFactory constructor.
+     *
      * @param string $host
      * @param string $database
      * @param string $udpPort
@@ -47,8 +48,7 @@ class InfluxDbClientFactory
         string $httpPort,
         string $username = '',
         string $password = ''
-    )
-    {
+    ) {
         $this->host = $host;
         $this->database = $database;
         $this->udpPort = $udpPort;
@@ -62,7 +62,7 @@ class InfluxDbClientFactory
      */
     public function buildUdpClient(): Database
     {
-        $client = new Client($this->host,$this->udpPort, $this->username, $this->password);
+        $client = new Client($this->host, $this->udpPort, $this->username, $this->password);
         $client->setDriver(new UDP($this->host, $this->udpPort));
 
         return $client->selectDB($this->database);
@@ -73,9 +73,8 @@ class InfluxDbClientFactory
      */
     public function buildHttpClient(): Database
     {
-        $client = new Client($this->host,$this->httpPort, $this->username, $this->password);
+        $client = new Client($this->host, $this->httpPort, $this->username, $this->password);
 
         return $client->selectDB($this->database);
     }
-
 }

--- a/src/Services/Clients/ReaderClient.php
+++ b/src/Services/Clients/ReaderClient.php
@@ -1,27 +1,27 @@
 <?php
+
 declare(strict_types=1);
+
 namespace Algatux\InfluxDbBundle\Services\Clients;
 
 use Algatux\InfluxDbBundle\Services\Clients\Contracts\ReaderInterface;
 use InfluxDB\Database;
 
 /**
- * Class ReaderClient
- * @package Algatux\InfluxDbBundle\Services\Clients
+ * Class ReaderClient.
  */
 class ReaderClient implements ReaderInterface
 {
-
-    /** @var Database  */
+    /** @var Database */
     private $database;
 
     /**
      * ReaderClient constructor.
+     *
      * @param InfluxDbClientFactory $clientFactory
      */
     public function __construct(InfluxDbClientFactory $clientFactory)
     {
         $this->database = $clientFactory->buildHttpClient();
     }
-
 }

--- a/src/Services/Clients/WriterClient.php
+++ b/src/Services/Clients/WriterClient.php
@@ -1,5 +1,7 @@
 <?php
+
 declare(strict_types=1);
+
 namespace Algatux\InfluxDbBundle\Services\Clients;
 
 use Algatux\InfluxDbBundle\Model\PointsCollection;
@@ -8,19 +10,18 @@ use Algatux\InfluxDbBundle\Services\Clients\Contracts\WriterInterface;
 use InfluxDB\Database;
 
 /**
- * Class WriterClient
- * @package Algatux\InfluxDbBundle\Services\Clients
+ * Class WriterClient.
  */
 class WriterClient implements WriterInterface
 {
-
-    /** @var Database  */
+    /** @var Database */
     private $database;
 
     /**
      * WriterClient constructor.
+     *
      * @param InfluxDbClientFactory $factory
-     * @param string $clientType
+     * @param string                $clientType
      */
     public function __construct(InfluxDbClientFactory $factory, string $clientType)
     {
@@ -31,11 +32,11 @@ class WriterClient implements WriterInterface
 
     /**
      * @param PointsCollection $points
+     *
      * @return bool
      */
     public function write(PointsCollection $points): bool
     {
         return $this->database->writePoints($points->toArray(), $points->getPrecision());
     }
-
 }

--- a/src/Services/CollectionStorageInterface.php
+++ b/src/Services/CollectionStorageInterface.php
@@ -1,18 +1,17 @@
 <?php
+
 declare(strict_types=1);
+
 namespace Algatux\InfluxDbBundle\Services;
 
 use Algatux\InfluxDbBundle\Model\PointsCollection;
 
 /**
- * Interface CollectionStorageInterface
- * @package Algatux\InfluxDbBundle\Services
+ * Interface CollectionStorageInterface.
  */
 interface CollectionStorageInterface
 {
-
     public function storeCollection(PointsCollection $collection, string $writeMode);
 
     public function getStoredCollections(): array;
-
 }

--- a/src/Services/PointsCollectionStorage.php
+++ b/src/Services/PointsCollectionStorage.php
@@ -1,17 +1,17 @@
 <?php
+
 declare(strict_types=1);
+
 namespace Algatux\InfluxDbBundle\Services;
 
 use Algatux\InfluxDbBundle\Model\PointsCollection;
 
 /**
- * Class PointsCollectionStorage
- * @package Algatux\InfluxDbBundle\Services
+ * Class PointsCollectionStorage.
  */
 class PointsCollectionStorage implements CollectionStorageInterface
 {
-
-    /** @var array  */
+    /** @var array */
     protected $storage;
 
     /**
@@ -24,7 +24,7 @@ class PointsCollectionStorage implements CollectionStorageInterface
 
     /**
      * @param PointsCollection $collection
-     * @param string $writeMode
+     * @param string           $writeMode
      */
     public function storeCollection(PointsCollection $collection, string $writeMode)
     {
@@ -46,7 +46,7 @@ class PointsCollectionStorage implements CollectionStorageInterface
      */
     private function checkStorageInitialization(string $getWriteMode, string $getPrecision)
     {
-        if (! isset($this->storage[$getWriteMode])) {
+        if (!isset($this->storage[$getWriteMode])) {
             $this->storage[$getWriteMode] = null;
         }
 
@@ -56,8 +56,9 @@ class PointsCollectionStorage implements CollectionStorageInterface
     }
 
     /**
-     * @param string $writemode
+     * @param string           $writemode
      * @param PointsCollection $points
+     *
      * @internal param InfluxDbEvent $event
      */
     private function mergeCollections(string $writemode, PointsCollection $points)
@@ -69,7 +70,5 @@ class PointsCollectionStorage implements CollectionStorageInterface
             $actualCollection->toArray(),
             $points->toArray()
         ), $points->getPrecision());
-
     }
-    
 }

--- a/tests/unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/unit/DependencyInjection/ConfigurationTest.php
@@ -1,5 +1,7 @@
 <?php
+
 declare(strict_types=1);
+
 namespace Algatux\InfluxDbBundle\Tests\unit;
 
 use Algatux\InfluxDbBundle\DependencyInjection\Configuration;
@@ -8,7 +10,6 @@ use Symfony\Component\Config\Definition\Processor;
 
 class ConfigurationTest extends \PHPUnit_Framework_TestCase
 {
-
     public function test_configuration_tree_build()
     {
         $conf = new Configuration();
@@ -17,7 +18,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $builtConf = $tree->buildTree();
 
         $this->assertInstanceOf(ArrayNode::class, $builtConf);
-        $this->assertEquals('influx_db',$builtConf->getName());
+        $this->assertEquals('influx_db', $builtConf->getName());
 
         $processor = new Processor();
 
@@ -27,9 +28,8 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('http_port', $conf);
         $this->assertArrayHasKey('use_events', $conf);
 
-        $this->assertEquals('4444',$conf['udp_port']);
-        $this->assertEquals('8086',$conf['http_port']);
-        $this->assertEquals(false,$conf['use_events']);
+        $this->assertEquals('4444', $conf['udp_port']);
+        $this->assertEquals('8086', $conf['http_port']);
+        $this->assertEquals(false, $conf['use_events']);
     }
-    
 }

--- a/tests/unit/DependencyInjection/InfluxDbExtensionTest.php
+++ b/tests/unit/DependencyInjection/InfluxDbExtensionTest.php
@@ -1,5 +1,7 @@
 <?php
+
 declare(strict_types=1);
+
 namespace Algatux\InfluxDbBundle\unit\DependencyInjection;
 
 use Algatux\InfluxDbBundle\DependencyInjection\InfluxDbExtension;
@@ -7,24 +9,21 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class InfluxDbExtensionTest extends \PHPUnit_Framework_TestCase
 {
-
     public function test_load()
     {
-
         $confTest = [
             'influx_db' => [
-                'host' => "localhost",
-                'database' => "udp",
-                'udp_port' => "4444",
-                'http_port' => "8086",
+                'host' => 'localhost',
+                'database' => 'udp',
+                'udp_port' => '4444',
+                'http_port' => '8086',
                 'use_events' => true,
-            ]
+            ],
         ];
 
         $extension = new InfluxDbExtension();
-        $config = $extension->load($confTest,new ContainerBuilder());
+        $config = $extension->load($confTest, new ContainerBuilder());
 
         $this->assertNotEmpty($config);
     }
-
 }

--- a/tests/unit/Events/InfluxDbEventTest.php
+++ b/tests/unit/Events/InfluxDbEventTest.php
@@ -1,24 +1,23 @@
 <?php
+
 declare(strict_types=1);
+
 namespace Algatux\InfluxDbBundle\unit\Events;
 
 use Algatux\InfluxDbBundle\Events\HttpEvent;
 use Algatux\InfluxDbBundle\Events\InfluxDbEvent;
 use Algatux\InfluxDbBundle\Model\PointsCollection;
 use Algatux\InfluxDbBundle\Services\Clients\Contracts\ClientInterface;
-use InfluxDB\Database;
 
 class InfluxDbEventTest extends \PHPUnit_Framework_TestCase
 {
-
     public function test_event_interface()
     {
-        $event = new HttpEvent(new PointsCollection([1,2,3]), ClientInterface::HTTP_CLIENT);
+        $event = new HttpEvent(new PointsCollection([1, 2, 3]), ClientInterface::HTTP_CLIENT);
 
         $this->assertInstanceOf(InfluxDbEvent::class, $event);
 
-        $this->assertEquals(new PointsCollection([1,2,3]), $event->getPoints());
+        $this->assertEquals(new PointsCollection([1, 2, 3]), $event->getPoints());
         $this->assertEquals(ClientInterface::HTTP_CLIENT, $event->getWriteMode());
     }
-    
 }

--- a/tests/unit/Events/Listeners/InfluxDbEventListenerTest.php
+++ b/tests/unit/Events/Listeners/InfluxDbEventListenerTest.php
@@ -1,5 +1,7 @@
 <?php
+
 declare(strict_types=1);
+
 namespace Algatux\InfluxDbBundle\unit\Events\Listeners;
 
 use Algatux\InfluxDbBundle\Events\DeferredHttpEvent;
@@ -10,13 +12,11 @@ use Algatux\InfluxDbBundle\Events\UdpEvent;
 use Algatux\InfluxDbBundle\Model\PointsCollection;
 use Algatux\InfluxDbBundle\Services\Clients\WriterClient;
 use Algatux\InfluxDbBundle\Services\PointsCollectionStorage;
-use InfluxDB\Database;
 use Prophecy\Argument;
 use Symfony\Component\EventDispatcher\Event;
 
 class InfluxDbEventListenerTest extends \PHPUnit_Framework_TestCase
 {
-
     public function test_listening_for_udp_infuxdb_event()
     {
         $event = new UdpEvent(new PointsCollection());
@@ -70,14 +70,14 @@ class InfluxDbEventListenerTest extends \PHPUnit_Framework_TestCase
             ->shouldBeCalledTimes(3);
         $storage->getStoredCollections()
             ->shouldBeCalledTimes(1)
-            ->willReturn(['udp' => ['s' => new PointsCollection([1,2,3])]]);
+            ->willReturn(['udp' => ['s' => new PointsCollection([1, 2, 3])]]);
 
         $httpWriter = $this->prophesize(WriterClient::class);
         $httpWriter->write(Argument::cetera())
             ->shouldNotBeCalled();
 
         $udpWriter = $this->prophesize(WriterClient::class);
-        $udpWriter->write(new PointsCollection([1,2,3]))
+        $udpWriter->write(new PointsCollection([1, 2, 3]))
             ->shouldBeCalledTimes(1)
             ->willReturn(true);
 
@@ -101,10 +101,10 @@ class InfluxDbEventListenerTest extends \PHPUnit_Framework_TestCase
 
         $storage->getStoredCollections()
             ->shouldBeCalledTimes(1)
-            ->willReturn(['http' => ['s' => new PointsCollection([1,2,3])]]);
+            ->willReturn(['http' => ['s' => new PointsCollection([1, 2, 3])]]);
 
         $httpWriter = $this->prophesize(WriterClient::class);
-        $httpWriter->write(new PointsCollection([1,2,3]))
+        $httpWriter->write(new PointsCollection([1, 2, 3]))
             ->shouldBeCalledTimes(1)
             ->willReturn(true);
 
@@ -119,5 +119,4 @@ class InfluxDbEventListenerTest extends \PHPUnit_Framework_TestCase
 
         $listener->onKernelTerminate(new Event());
     }
-
 }

--- a/tests/unit/InfluxDbBundleTest.php
+++ b/tests/unit/InfluxDbBundleTest.php
@@ -1,4 +1,5 @@
 <?php
+
 //declare(strict_types=1);
 
 namespace Algatux\InfluxDbBundle\unit;
@@ -9,17 +10,13 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class InfluxDbBundleTest extends \PHPUnit_Framework_TestCase
 {
-
     public function test_get_container_extension()
     {
-
         $bundle = new InfluxDbBundle();
 
         $extension = $bundle->getContainerExtension();
 
         $this->assertInstanceOf(Bundle::class, $bundle);
         $this->assertInstanceOf(InfluxDbExtension::class, $extension);
-
-    }    
-    
+    }
 }

--- a/tests/unit/Services/Clients/InfluxDbClientFactoryTest.php
+++ b/tests/unit/Services/Clients/InfluxDbClientFactoryTest.php
@@ -1,17 +1,16 @@
 <?php
+
 //declare(strict_types=1);
 
 namespace Algatux\InfluxDbBundle\Tests\unit\Services\Clients;
 
 use Algatux\InfluxDbBundle\Services\Clients\InfluxDbClientFactory;
-use InfluxDB\Client;
 use InfluxDB\Database;
 use InfluxDB\Driver\Guzzle;
 use InfluxDB\Driver\UDP;
 
 class InfluxDbClientFactoryTest extends \PHPUnit_Framework_TestCase
 {
-
     const TEST_HOST = 'localhost';
     const TEST_DB = 'udp';
     const TEST_UDP = '4444';
@@ -19,31 +18,29 @@ class InfluxDbClientFactoryTest extends \PHPUnit_Framework_TestCase
     const TEST_USERNAME = 'username';
     const TEST_PASSWORD = 'password';
 
-
     public function test_client_factory_test_exists()
     {
-        $factory = new InfluxDbClientFactory(self::TEST_HOST,self::TEST_DB,self::TEST_UDP,self::TEST_HTTP, self::TEST_USERNAME, self::TEST_PASSWORD);
+        $factory = new InfluxDbClientFactory(self::TEST_HOST, self::TEST_DB, self::TEST_UDP, self::TEST_HTTP, self::TEST_USERNAME, self::TEST_PASSWORD);
         $this->assertInstanceOf(InfluxDbClientFactory::class, $factory);
     }
 
     public function test_build_udp_client_returns_a_valid_client()
     {
-        $factory = new InfluxDbClientFactory(self::TEST_HOST,self::TEST_DB,self::TEST_UDP,self::TEST_HTTP, self::TEST_USERNAME, self::TEST_PASSWORD);
+        $factory = new InfluxDbClientFactory(self::TEST_HOST, self::TEST_DB, self::TEST_UDP, self::TEST_HTTP, self::TEST_USERNAME, self::TEST_PASSWORD);
         $database = $factory->buildUdpClient();
 
         $this->assertInstanceOf(Database::class, $database);
         $this->assertEquals(self::TEST_DB, $database->getName());
-        $this->assertInstanceOf(UDP::class,$database->getClient()->getDriver());
+        $this->assertInstanceOf(UDP::class, $database->getClient()->getDriver());
     }
 
     public function test_build_http_client_returns_a_valid_client()
     {
-        $factory = new InfluxDbClientFactory(self::TEST_HOST,self::TEST_DB,self::TEST_UDP,self::TEST_HTTP, self::TEST_USERNAME, self::TEST_PASSWORD);
+        $factory = new InfluxDbClientFactory(self::TEST_HOST, self::TEST_DB, self::TEST_UDP, self::TEST_HTTP, self::TEST_USERNAME, self::TEST_PASSWORD);
         $database = $factory->buildHttpClient();
 
         $this->assertInstanceOf(Database::class, $database);
         $this->assertEquals(self::TEST_DB, $database->getName());
-        $this->assertInstanceOf(Guzzle::class,$database->getClient()->getDriver());
+        $this->assertInstanceOf(Guzzle::class, $database->getClient()->getDriver());
     }
-
 }

--- a/tests/unit/Services/Clients/ReaderClientTest.php
+++ b/tests/unit/Services/Clients/ReaderClientTest.php
@@ -1,5 +1,7 @@
 <?php
+
 declare(strict_types=1);
+
 namespace Algatux\InfluxDbBundle\unit\Services\Clients;
 
 use Algatux\InfluxDbBundle\Services\Clients\Contracts\ReaderInterface;
@@ -8,7 +10,6 @@ use Algatux\InfluxDbBundle\Services\Clients\ReaderClient;
 
 class ReaderClientTest extends \PHPUnit_Framework_TestCase
 {
-
     public function test_http_client_construction()
     {
         $factory = $this->prophesize(InfluxDbClientFactory::class);
@@ -18,5 +19,4 @@ class ReaderClientTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf(ReaderInterface::class, $reader);
     }
-
 }

--- a/tests/unit/Services/Clients/WriterClientTest.php
+++ b/tests/unit/Services/Clients/WriterClientTest.php
@@ -1,5 +1,7 @@
 <?php
+
 declare(strict_types=1);
+
 namespace Algatux\InfluxDbBundle\unit\Services\Clients;
 
 use Algatux\InfluxDbBundle\Model\PointsCollection;
@@ -7,13 +9,11 @@ use Algatux\InfluxDbBundle\Services\Clients\Contracts\ClientInterface;
 use Algatux\InfluxDbBundle\Services\Clients\Contracts\WriterInterface;
 use Algatux\InfluxDbBundle\Services\Clients\InfluxDbClientFactory;
 use Algatux\InfluxDbBundle\Services\Clients\WriterClient;
-use InfluxDB\Client;
 use InfluxDB\Database;
 use Prophecy\Argument;
 
 class WriterClientTest extends \PHPUnit_Framework_TestCase
 {
-
     public function test_http_client_construction()
     {
         $factory = $this->prophesize(InfluxDbClientFactory::class);
@@ -37,7 +37,7 @@ class WriterClientTest extends \PHPUnit_Framework_TestCase
     public function test_write()
     {
         $idbDatabase = $this->prophesize(Database::class);
-        $idbDatabase->writePoints(Argument::type('array'),Argument::type('string'))
+        $idbDatabase->writePoints(Argument::type('array'), Argument::type('string'))
             ->shouldBeCalledTimes(1)
             ->willReturn(true);
 
@@ -45,7 +45,6 @@ class WriterClientTest extends \PHPUnit_Framework_TestCase
         $factory->buildHttpClient()->shouldBeCalledTimes(1)->willReturn($idbDatabase->reveal());
 
         $writer = new WriterClient($factory->reveal(), ClientInterface::HTTP_CLIENT);
-        $writer->write(new PointsCollection(),'test');
+        $writer->write(new PointsCollection(), 'test');
     }
-    
 }

--- a/tests/unit/Services/PointCollectionStorageTest.php
+++ b/tests/unit/Services/PointCollectionStorageTest.php
@@ -8,23 +8,21 @@ use Algatux\InfluxDbBundle\Services\PointsCollectionStorage;
 use InfluxDB\Database;
 
 /**
- * Class PointCollectionStorageTest
- * @package Algatux\InfluxDbBundle\unit\Services
+ * Class PointCollectionStorageTest.
  */
 class PointCollectionStorageTest extends \PHPUnit_Framework_TestCase
 {
-
     public function test_instance_of_collections_storage_interface()
     {
         $this->assertInstanceOf(CollectionStorageInterface::class, new PointsCollectionStorage());
     }
-    
+
     public function test_store_single_collection()
     {
-        $points = new PointsCollection([1],Database::PRECISION_SECONDS);
+        $points = new PointsCollection([1], Database::PRECISION_SECONDS);
 
         $store = new PointsCollectionStorage();
-        $store->storeCollection($points,'udp');
+        $store->storeCollection($points, 'udp');
 
         $collections = $store->getStoredCollections();
         $this->assertCount(1, $collections['udp']['s']);
@@ -32,21 +30,20 @@ class PointCollectionStorageTest extends \PHPUnit_Framework_TestCase
 
     public function test_store_multiple_collection()
     {
-        $points1 = new PointsCollection([1],Database::PRECISION_SECONDS);
-        $points2 = new PointsCollection([2],Database::PRECISION_SECONDS);
-        $points3 = new PointsCollection([3],Database::PRECISION_SECONDS);
+        $points1 = new PointsCollection([1], Database::PRECISION_SECONDS);
+        $points2 = new PointsCollection([2], Database::PRECISION_SECONDS);
+        $points3 = new PointsCollection([3], Database::PRECISION_SECONDS);
 
         $store = new PointsCollectionStorage();
-        $store->storeCollection($points1,'udp');
-        $store->storeCollection($points2,'udp');
-        $store->storeCollection($points3,'udp');
+        $store->storeCollection($points1, 'udp');
+        $store->storeCollection($points2, 'udp');
+        $store->storeCollection($points3, 'udp');
 
         $collections = $store->getStoredCollections();
 
-        $this->assertArrayHasKey('udp',$collections);
-        $this->assertArrayHasKey('s',$collections['udp']);
+        $this->assertArrayHasKey('udp', $collections);
+        $this->assertArrayHasKey('s', $collections['udp']);
         $this->assertInstanceOf(PointsCollection::class, $collections['udp']['s']);
         $this->assertCount(3, $collections['udp']['s']);
     }
-
 }


### PR DESCRIPTION
## The tool

StyleCI is a service to check and fix PHP coding style: https://styleci.io/

To enable it, just login on this website with your GitHub account and add your repositories.

StyleCI can:
- Add a status on a PR to prevent bad coding style
- Propose automatic PR to fix bad coding style present on the master branch

StyleCI is based on PHP-CS-Fixer tools.

To let the possibility to fix CS from command line, the sllh/php-cs-fixer-styleci-bridge is used as a configuration bridge.
## Why coding style matters?

Coding style matters for many things:
- It ensures code consistency
- It makes code cleaner and easier to read
- It avoid ugly diff of unnecessary commit like I had to before: https://github.com/Algatux/influxdb-bundle/pull/1/commits/e19a00664976ba9476266716a836eb16d937f86e (BTW, I suggest you to use [`.editorconfig`](http://editorconfig.org/) file too for other file than PHP).

Trust me, having a good Coding Style on your project will give only benefits. :wink: 
## Which CS convention

As your project is a bundle, I choose the [Symfony Coding Standards](http://symfony.com/doc/current/contributing/code/standards.html) plus some extra good fixers.

If you want to change it, feel free.

I'll add a CS fixing commit after this one to show you the result, and apply it on master. :+1: 

Note: You **should not** do a merge by squash for this one. :+1: 
