### PR TITLE
Refactoring the client and databases services

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -48,9 +48,22 @@ influx_db:
     use_events: true (default false)
 ```
 
-### Sending data to influx db
+### Services
 
-assuming this collection to send:
+You can directly access to the `InfluxDB\Database` trough UDP or HTTP with those services:
+
+```php
+$httpDatabase = $this->get('algatux_influx_db.database.http');
+$udpDatabase = $this->get('algatux_influx_db.database.udp');
+```
+
+To manipulate the database, please read the official documentation
+for [reading](https://github.com/influxdata/influxdb-php#reading)
+and [writing](https://github.com/influxdata/influxdb-php#writing-data).
+
+### Sending data to influx db trough events
+
+Assuming this collection to send:
 
 ```php
 $time = new \DateTime();
@@ -65,21 +78,8 @@ $points = new PointsCollection([new Point(
 
 ```
 
-###### Service
-```php
-// UDP
-$container
-    ->get('algatux_influx_db.client.udp.writer_client')
-    ->write($points);
+Dispatch the event instance according to the chosen writing protocol:
 
-// HTTP
-$container
-    ->get('algatux_influx_db.client.http.writer_client')
-    ->write($points);
-
-```
-
-###### Event Dispatcher
 ```php
 // UDP
 $container
@@ -90,8 +90,11 @@ $container
 $container
     ->get('event_dispatcher')
     ->dispatch(InfluxDbEvent::NAME, new HttpEvent($points));
+```
 
+Or, if you prefer to defer the event:
 
+```php
 // Deferred Events
 // Collect your measurements during the request and make only one write to influxdb.
 // Deferred events are catched and "stored". Than on the kernel.terminate event one write per
@@ -106,7 +109,4 @@ $container
 $container
     ->get('event_dispatcher')
     ->dispatch(InfluxDbEvent::NAME, new DeferredHttpEvent($points));
-
 ```
-
-

--- a/UPGRADE-1.x.md
+++ b/UPGRADE-1.x.md
@@ -1,0 +1,31 @@
+UPGRADE FROM 1.0 to 1.1
+=======================
+
+## Deprecated services
+
+Some services are deprecated and should not be used anymore:
+
+* `algatux_influx_db.services_clients.influx_db_client_factory`
+* `algatux_influx_db.client.udp.writer_client`
+* `algatux_influx_db.client.http.writer_client`
+
+Use `Database` services instead:
+
+* `algatux_influx_db.database.http`
+* `algatux_influx_db.database.udp`
+
+## Deprecated class
+
+Some class are deprecated and should not be used anymore:
+
+* `Algatux\InfluxDbBundle\Services\Clients\InfluxDbClientFactory`
+* `Algatux\InfluxDbBundle\Services\Clients\WriterClient`
+* `Algatux\InfluxDbBundle\Services\Clients\ReaderClient`
+
+## Deprecated interfaces
+
+Some interfaces are deprecated and should not be used anymore:
+
+* `Algatux\InfluxDbBundle\Services\Clients\Contracts\ClientInterface`
+* `Algatux\InfluxDbBundle\Services\Clients\Contracts\ReaderInterface`
+* `Algatux\InfluxDbBundle\Services\Clients\Contracts\WriterInterface`

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "symfony/config": "^2.8 || ^3.0",
         "symfony/dependency-injection": "^2.8 || ^3.0",
         "symfony/event-dispatcher": "^2.8 || ^3.0",
-        "symfony/http-kernel": "^2.8 || ^3.0"
+        "symfony/http-kernel": "^2.8 || ^3.0",
+        "symfony/phpunit-bridge": "^3.1"
     },
     "require-dev": {
         "matthiasnoback/symfony-dependency-injection-test": "^0.7.6",

--- a/src/DependencyInjection/InfluxDbExtension.php
+++ b/src/DependencyInjection/InfluxDbExtension.php
@@ -31,6 +31,8 @@ class InfluxDbExtension extends Extension
 
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
+        $loader->load('clients.xml');
+        $loader->load('databases.xml');
 
         if ($config['use_events'] === true) {
             $loader->load('listeners.xml');

--- a/src/Resources/config/clients.xml
+++ b/src/Resources/config/clients.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services
+        http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+
+        <service id="algatux_influx_db.client.http" class="InfluxDB\Client" public="false">
+            <factory class="Algatux\InfluxDbBundle\Services\ClientFactory" method="createClient"/>
+            <argument>%influx_db.host%</argument>
+            <argument>%influx_db.http.port%</argument>
+            <argument>%influx_db.udp.port%</argument>
+            <argument>%influx_db.username%</argument>
+            <argument>%influx_db.password%</argument>
+        </service>
+
+        <service id="algatux_influx_db.client.udp" class="InfluxDB\Client" public="false">
+            <factory class="Algatux\InfluxDbBundle\Services\ClientFactory" method="createClient"/>
+            <argument>%influx_db.host%</argument>
+            <argument>%influx_db.http.port%</argument>
+            <argument>%influx_db.udp.port%</argument>
+            <argument>%influx_db.username%</argument>
+            <argument>%influx_db.password%</argument>
+            <argument>true</argument>
+        </service>
+
+    </services>
+</container>

--- a/src/Resources/config/databases.xml
+++ b/src/Resources/config/databases.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services
+        http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+
+        <service id="algatux_influx_db.database.http" class="InfluxDB\Database">
+            <factory service="algatux_influx_db.client.http" method="selectDB"/>
+            <argument>%influx_db.database%</argument>
+        </service>
+
+        <service id="algatux_influx_db.database.udp" class="InfluxDB\Database">
+            <factory service="algatux_influx_db.client.udp" method="selectDB"/>
+            <argument>%influx_db.database%</argument>
+        </service>
+
+    </services>
+</container>

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -15,6 +15,7 @@
             <argument>%influx_db.http.port%</argument>
             <argument>%influx_db.username%</argument>
             <argument>%influx_db.password%</argument>
+            <deprecated>The "%service_id%" service is deprecated since version 1.1 and will be removed in 2.0.</deprecated>
         </service>
 
         <!--WriterClient UDP -->
@@ -22,6 +23,7 @@
                  id="algatux_influx_db.client.udp.writer_client">
             <argument id="algatux_influx_db.services_clients.influx_db_client_factory" type="service"/>
             <argument type="string">udp</argument>
+            <deprecated>The "%service_id%" service is deprecated since version 1.1 and will be removed in 2.0.</deprecated>
         </service>
 
         <!--WriterClient HTTP -->
@@ -29,6 +31,7 @@
                  id="algatux_influx_db.client.http.writer_client">
             <argument id="algatux_influx_db.services_clients.influx_db_client_factory" type="service"/>
             <argument type="string">http</argument>
+            <deprecated>The "%service_id%" service is deprecated since version 1.1 and will be removed in 2.0.</deprecated>
         </service>
 
         <!--ReaderClient HTTP -->

--- a/src/Services/ClientFactory.php
+++ b/src/Services/ClientFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Algatux\InfluxDbBundle\Services;
+
+use InfluxDB\Client;
+
+/**
+ * Factory to build InfluxDB\Client instances.
+ */
+final class ClientFactory
+{
+    /**
+     * @param string $host
+     * @param string $httpPort
+     * @param string $udpPort
+     * @param string $user
+     * @param string $password
+     * @param bool   $udp
+     *
+     * @return Client
+     */
+    public static function createClient(string $host, string $httpPort, string $udpPort, string $user, string $password, bool $udp = false)
+    {
+        $client = new Client($host, $httpPort, $user, $password);
+
+        if ($udp) {
+            $client->setDriver(new \InfluxDB\Driver\UDP($client->getHost(), $udpPort));
+        }
+
+        return $client;
+    }
+}

--- a/src/Services/Clients/Contracts/ClientInterface.php
+++ b/src/Services/Clients/Contracts/ClientInterface.php
@@ -4,8 +4,15 @@ declare(strict_types=1);
 
 namespace Algatux\InfluxDbBundle\Services\Clients\Contracts;
 
+@trigger_error(
+    'The '.__NAMESPACE__.'\ClientInterface interface is deprecated since version 1.1 and will be removed in 2.0.',
+    E_USER_DEPRECATED
+);
+
 /**
  * Interface ClientInterface.
+ *
+ * @deprecated Since version 1.1, to be removed in 2.0.
  */
 interface ClientInterface
 {

--- a/src/Services/Clients/Contracts/ReaderInterface.php
+++ b/src/Services/Clients/Contracts/ReaderInterface.php
@@ -4,8 +4,15 @@ declare(strict_types=1);
 
 namespace Algatux\InfluxDbBundle\Services\Clients\Contracts;
 
+@trigger_error(
+    'The '.__NAMESPACE__.'\ReaderInterface interface is deprecated since version 1.1 and will be removed in 2.0.',
+    E_USER_DEPRECATED
+);
+
 /**
  * Interface ReaderInterface.
+ *
+ * @deprecated Since version 1.1, to be removed in 2.0.
  */
 interface ReaderInterface
 {

--- a/src/Services/Clients/Contracts/WriterInterface.php
+++ b/src/Services/Clients/Contracts/WriterInterface.php
@@ -6,8 +6,15 @@ namespace Algatux\InfluxDbBundle\Services\Clients\Contracts;
 
 use Algatux\InfluxDbBundle\Model\PointsCollection;
 
+@trigger_error(
+    'The '.__NAMESPACE__.'\WriterInterface interface is deprecated since version 1.1 and will be removed in 2.0.',
+    E_USER_DEPRECATED
+);
+
 /**
  * Interface WriterInterface.
+ *
+ * @deprecated Since version 1.1, to be removed in 2.0.
  */
 interface WriterInterface
 {

--- a/src/Services/Clients/InfluxDbClientFactory.php
+++ b/src/Services/Clients/InfluxDbClientFactory.php
@@ -8,8 +8,15 @@ use InfluxDB\Client;
 use InfluxDB\Database;
 use InfluxDB\Driver\UDP;
 
+@trigger_error(
+    'The '.__NAMESPACE__.'\InfluxDbClientFactory class is deprecated since version 1.1 and will be removed in 2.0.',
+    E_USER_DEPRECATED
+);
+
 /**
  * Class InfluxDbClientFactory.
+ *
+ * @deprecated Since version 1.1, to be removed in 2.0.
  */
 class InfluxDbClientFactory
 {

--- a/src/Services/Clients/ReaderClient.php
+++ b/src/Services/Clients/ReaderClient.php
@@ -7,8 +7,15 @@ namespace Algatux\InfluxDbBundle\Services\Clients;
 use Algatux\InfluxDbBundle\Services\Clients\Contracts\ReaderInterface;
 use InfluxDB\Database;
 
+@trigger_error(
+    'The '.__NAMESPACE__.'\ReaderClient class is deprecated since version 1.1 and will be removed in 2.0.',
+    E_USER_DEPRECATED
+);
+
 /**
  * Class ReaderClient.
+ *
+ * @deprecated Since version 1.1, to be removed in 2.0.
  */
 class ReaderClient implements ReaderInterface
 {

--- a/src/Services/Clients/WriterClient.php
+++ b/src/Services/Clients/WriterClient.php
@@ -9,8 +9,15 @@ use Algatux\InfluxDbBundle\Services\Clients\Contracts\ClientInterface;
 use Algatux\InfluxDbBundle\Services\Clients\Contracts\WriterInterface;
 use InfluxDB\Database;
 
+@trigger_error(
+    'The '.__NAMESPACE__.'\WriterClient class is deprecated since version 1.1 and will be removed in 2.0.',
+    E_USER_DEPRECATED
+);
+
 /**
  * Class WriterClient.
+ *
+ * @deprecated Since version 1.1, to be removed in 2.0.
  */
 class WriterClient implements WriterInterface
 {

--- a/tests/unit/DependencyInjection/InfluxDbExtensionTest.php
+++ b/tests/unit/DependencyInjection/InfluxDbExtensionTest.php
@@ -18,6 +18,24 @@ class InfluxDbExtensionTest extends AbstractExtensionTestCase
     {
         $this->load();
 
+        $this->assertContainerBuilderHasService('algatux_influx_db.database.http', Database::class);
+        $httpDatabase = $this->container->get('algatux_influx_db.database.http');
+        $this->assertInstanceOf(Database::class, $httpDatabase);
+        $this->assertSame('telegraf', $httpDatabase->getName());
+
+        $this->assertContainerBuilderHasService('algatux_influx_db.database.udp', Database::class);
+        $udpDatabase = $this->container->get('algatux_influx_db.database.udp');
+        $this->assertInstanceOf(Database::class, $udpDatabase);
+        $this->assertSame('telegraf', $udpDatabase->getName());
+    }
+
+    /**
+     * @group legacy
+     */
+    public function test_load_legacy_services()
+    {
+        $this->load();
+
         $this->assertContainerBuilderHasService('algatux_influx_db.services_clients.influx_db_client_factory', InfluxDbClientFactory::class);
         $this->assertContainerBuilderHasService('algatux_influx_db.client.udp.writer_client', WriterClient::class);
         $this->assertContainerBuilderHasService('algatux_influx_db.client.http.writer_client', WriterClient::class);

--- a/tests/unit/Services/Clients/InfluxDbClientFactoryTest.php
+++ b/tests/unit/Services/Clients/InfluxDbClientFactoryTest.php
@@ -9,6 +9,9 @@ use InfluxDB\Database;
 use InfluxDB\Driver\Guzzle;
 use InfluxDB\Driver\UDP;
 
+/**
+ * @group legacy
+ */
 class InfluxDbClientFactoryTest extends \PHPUnit_Framework_TestCase
 {
     const TEST_HOST = 'localhost';

--- a/tests/unit/Services/Clients/ReaderClientTest.php
+++ b/tests/unit/Services/Clients/ReaderClientTest.php
@@ -8,6 +8,9 @@ use Algatux\InfluxDbBundle\Services\Clients\Contracts\ReaderInterface;
 use Algatux\InfluxDbBundle\Services\Clients\InfluxDbClientFactory;
 use Algatux\InfluxDbBundle\Services\Clients\ReaderClient;
 
+/**
+ * @group legacy
+ */
 class ReaderClientTest extends \PHPUnit_Framework_TestCase
 {
     public function test_http_client_construction()

--- a/tests/unit/Services/Clients/WriterClientTest.php
+++ b/tests/unit/Services/Clients/WriterClientTest.php
@@ -12,6 +12,9 @@ use Algatux\InfluxDbBundle\Services\Clients\WriterClient;
 use InfluxDB\Database;
 use Prophecy\Argument;
 
+/**
+ * @group legacy
+ */
 class WriterClientTest extends \PHPUnit_Framework_TestCase
 {
     public function test_http_client_construction()


### PR DESCRIPTION
Closes #7

The goal is to allow a more generic database access for reading and http/udp writing.

Related to my comment: https://github.com/Algatux/influxdb-bundle/issues/7#issuecomment-223366149

This is a WIP, lot of thing is missing. I'll update the documentation and update the PR body to explain a bit more. :wink: 
- [x] Client factory (private client services)
- [x] Database factory
- [ ] Manage multiple client/databases?
- [x] Tests. Some packages might help:
  - https://packagist.org/packages/matthiasnoback/symfony-config-test
  - https://packagist.org/packages/matthiasnoback/symfony-dependency-injection-test
- [x] Update the documentation
- [x] Deprecate not needed services/instances
- [x] Upgrade file
