### PR TITLE
Make some classes final

### DIFF
--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -24,6 +24,19 @@ The following parameters does not exist anymore:
 * `influx_db.username`
 * `influx_db.password`
 
+## Final classes
+
+Some classes are now `final` and should not be overridden:
+
+* `Algatux\InfluxDbBundle\DependencyInjection\Configuration`
+* `Algatux\InfluxDbBundle\DependencyInjection\InfluxDbExtension`
+* `Algatux\InfluxDbBundle\Events\Listeners\InfluxDbEventListener`
+* `Algatux\InfluxDbBundle\Events\DeferredHttpEvent`
+* `Algatux\InfluxDbBundle\Events\DeferredUdpEvent`
+* `Algatux\InfluxDbBundle\Events\HttpEvent`
+* `Algatux\InfluxDbBundle\Events\UdpEvent`
+* `Algatux\InfluxDbBundle\InfluxDbBundle`
+
 ## Internal classes
 
 Some classes are now internal:

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -10,7 +10,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  *
  * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/configuration.html}
  */
-class Configuration implements ConfigurationInterface
+final class Configuration implements ConfigurationInterface
 {
     /**
      * {@inheritdoc}

--- a/src/DependencyInjection/InfluxDbExtension.php
+++ b/src/DependencyInjection/InfluxDbExtension.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
  *
  * @link http://symfony.com/doc/current/cookbook/bundles/extension.html
  */
-class InfluxDbExtension extends Extension
+final class InfluxDbExtension extends Extension
 {
     /**
      * {@inheritdoc}

--- a/src/Events/DeferredHttpEvent.php
+++ b/src/Events/DeferredHttpEvent.php
@@ -7,6 +7,6 @@ namespace Algatux\InfluxDbBundle\Events;
 /**
  * Class DeferredHttpEvent.
  */
-class DeferredHttpEvent extends AbstractDeferredInfluxDbEvent
+final class DeferredHttpEvent extends AbstractDeferredInfluxDbEvent
 {
 }

--- a/src/Events/DeferredUdpEvent.php
+++ b/src/Events/DeferredUdpEvent.php
@@ -7,6 +7,6 @@ namespace Algatux\InfluxDbBundle\Events;
 /**
  * Class DeferredUdpEvent.
  */
-class DeferredUdpEvent extends AbstractDeferredInfluxDbEvent
+final class DeferredUdpEvent extends AbstractDeferredInfluxDbEvent
 {
 }

--- a/src/Events/HttpEvent.php
+++ b/src/Events/HttpEvent.php
@@ -7,6 +7,6 @@ namespace Algatux\InfluxDbBundle\Events;
 /**
  * Class HttpEvent.
  */
-class HttpEvent extends AbstractInfluxDbEvent
+final class HttpEvent extends AbstractInfluxDbEvent
 {
 }

--- a/src/Events/Listeners/InfluxDbEventListener.php
+++ b/src/Events/Listeners/InfluxDbEventListener.php
@@ -15,7 +15,7 @@ use Symfony\Component\EventDispatcher\Event;
 /**
  * @internal
  */
-class InfluxDbEventListener
+final class InfluxDbEventListener
 {
     const STORAGE_KEY_UDP = 'udp';
     const STORAGE_KEY_HTTP = 'http';

--- a/src/Events/UdpEvent.php
+++ b/src/Events/UdpEvent.php
@@ -7,6 +7,6 @@ namespace Algatux\InfluxDbBundle\Events;
 /**
  * Class UdpEvent.
  */
-class UdpEvent extends AbstractInfluxDbEvent
+final class UdpEvent extends AbstractInfluxDbEvent
 {
 }

--- a/src/InfluxDbBundle.php
+++ b/src/InfluxDbBundle.php
@@ -5,7 +5,7 @@ namespace Algatux\InfluxDbBundle;
 use Algatux\InfluxDbBundle\DependencyInjection\InfluxDbExtension;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class InfluxDbBundle extends Bundle
+final class InfluxDbBundle extends Bundle
 {
     public function getContainerExtension()
     {


### PR DESCRIPTION
Those classes makes no sense to be overridden.

Making them final allow us more flexibility on code change.

Closes #26.
