### PR TITLE
Form types

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -92,6 +92,17 @@ $httpDatabase = $this->get('algatux_influx_db.connection.default.http');
 $udpDatabase = $this->get('algatux_influx_db.connection.default.udp');
 ```
 
+You can also retrieve them thanks to the registry:
+
+```php
+$database = $this->get('algatux_influx_db.connection_registry')->getDefaultHttpConnection();
+$database = $this->get('algatux_influx_db.connection_registry')->getDefaultUdpConnection();
+
+// Same as before.
+$database = $this->get('algatux_influx_db.connection_registry')->getHttpConnection('default');
+$database = $this->get('algatux_influx_db.connection_registry')->getUdpConnection('default');
+```
+
 To manipulate the database, please read the official documentation
 for [reading](https://github.com/influxdata/influxdb-php#reading)
 and [writing](https://github.com/influxdata/influxdb-php#writing-data).

--- a/README.MD
+++ b/README.MD
@@ -182,3 +182,32 @@ To get more information, run:
 ```bash
 ./app/console help <command>
 ```
+
+### Form types
+
+This bundle provides several pre-defined form types. They are useful but optional.
+
+If you want to use them, you have to require the `symfony/form` package.
+
+Description of each of them is on the class doc block. Here is a short usage example:
+
+```php
+$form
+    ->add('measurement', MeasurementType::class, [
+        'connection' => 'default' // Optional: The connection you want to use.
+    ])
+    ->add('fields', FieldKeyType::class, [
+        'measurement' => 'cpu', // The concerned measurement.
+        'multiple' => true, // Parent type is ChoiceType. You can use parent option like multiple.
+    ])
+    ->add('tags', TagKeyType::class, [
+        'measurement' => 'cpu',
+        'exclude_host' => false, // True by default. Excludes the 'host' choice value.
+        'multiple' => true,
+    ])
+    ->add('tag_value', TagValueType::class, [
+        'measurement' => 'disk',
+        'tag_key' => 'fstype', // The related tag key.
+    ])
+;
+```

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,14 @@
     "require-dev": {
         "matthiasnoback/symfony-dependency-injection-test": "^0.7.6",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
+        "symfony/form": "^2.8 || ^3.0",
         "symfony/phpunit-bridge": "^3.1"
+    },
+    "suggest": {
+        "symfony/form": "Needed for form types usage"
+    },
+    "conflict": {
+        "symfony/form": "<2.8 || >=4.0"
     },
     "autoload": {
         "psr-4": { "Algatux\\InfluxDbBundle\\": "src/" }

--- a/src/DependencyInjection/InfluxDbExtension.php
+++ b/src/DependencyInjection/InfluxDbExtension.php
@@ -9,6 +9,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
@@ -35,6 +36,10 @@ final class InfluxDbExtension extends Extension
         $this->buildConnections($container, $config, $defaultConnection);
 
         $this->setDefaultConnectionAlias($container, $defaultConnection);
+
+        if (interface_exists(FormInterface::class)) {
+            $loader->load('form.xml');
+        }
 
         return $config;
     }

--- a/src/Exception/ConnectionNotFoundException.php
+++ b/src/Exception/ConnectionNotFoundException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Algatux\InfluxDbBundle\Exception;
+
+/**
+ * Thrown when an InfluxDB connection can't be retrieved from the registry.
+ */
+final class ConnectionNotFoundException extends \RuntimeException
+{
+    /**
+     * @param string          $connectionName
+     * @param string          $protocol
+     * @param \Exception|null $previous
+     */
+    public function __construct(string $connectionName, string $protocol, \Exception $previous = null)
+    {
+        parent::__construct('Connection "'.$connectionName.'" for '.$protocol.' protocol does not exist.', 0, $previous);
+    }
+}

--- a/src/Form/Type/AbstractInfluxChoiceType.php
+++ b/src/Form/Type/AbstractInfluxChoiceType.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Algatux\InfluxDbBundle\Form\Type;
+
+use Algatux\InfluxDbBundle\Services\ConnectionRegistry;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\DataTransformerInterface;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Abstract class to get access to the InfluxDB connections registry.
+ */
+abstract class AbstractInfluxChoiceType extends AbstractType
+{
+    /**
+     * @var ConnectionRegistry
+     */
+    protected $connectionRegistry;
+
+    /**
+     * @param ConnectionRegistry $connectionRegistry
+     */
+    final public function setConnectionRegistry(ConnectionRegistry $connectionRegistry)
+    {
+        $this->connectionRegistry = $connectionRegistry;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver
+            ->setDefault('connection', null)
+            ->setAllowedTypes('connection', ['string', 'null'])
+        ;
+
+        // To be removed when bumping symfony/form constraint to version 3.1+
+        if (!in_array(DataTransformerInterface::class, class_implements(TextType::class))) {
+            $resolver->setDefault('choices_as_values', true);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParent()
+    {
+        return ChoiceType::class;
+    }
+
+    /**
+     * Executes the given query and converts the result to a proper choices list.
+     *
+     * @param string      $query
+     * @param string      $columnName
+     * @param string|null $connectionName
+     *
+     * @return array
+     */
+    final protected function loadChoicesFromQuery(string $query, string $columnName, string $connectionName = null)
+    {
+        $connection = $connectionName
+            ? $this->connectionRegistry->getHttpConnection($connectionName)
+            : $this->connectionRegistry->getDefaultHttpConnection()
+        ;
+        $measurements = array_map(function ($point) use ($columnName) {
+            return $point[$columnName];
+        }, $connection->query($query)->getPoints());
+
+        return array_combine(array_values($measurements), $measurements);
+    }
+}

--- a/src/Form/Type/FieldKeyType.php
+++ b/src/Form/Type/FieldKeyType.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Algatux\InfluxDbBundle\Form\Type;
+
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Choice type listing available field keys of a measurement.
+ */
+final class FieldKeyType extends AbstractInfluxChoiceType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        parent::configureOptions($resolver);
+
+        $resolver
+            ->setRequired('measurement')
+            ->setDefaults([
+                'choices' => function (Options $options) {
+                    return $this->loadChoicesFromQuery(
+                        sprintf(
+                            'SELECT fieldKey FROM "default"._fieldKeys WHERE _name = \'%s\'',
+                            $options['measurement']
+                        ),
+                        'fieldKey',
+                        $options['connection']
+                    );
+                },
+            ])
+            ->setAllowedTypes('measurement', ['string'])
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'influx_field_key';
+    }
+}

--- a/src/Form/Type/MeasurementType.php
+++ b/src/Form/Type/MeasurementType.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Algatux\InfluxDbBundle\Form\Type;
+
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Choice type listing available measurements.
+ */
+final class MeasurementType extends AbstractInfluxChoiceType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        parent::configureOptions($resolver);
+
+        $resolver
+            ->setDefaults([
+                'choices' => function (Options $options) {
+                    return $this->loadChoicesFromQuery(
+                        'SHOW MEASUREMENTS',
+                        'name',
+                        $options['connection']
+                    );
+                },
+            ])
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'influx_measurement';
+    }
+}

--- a/src/Form/Type/TagKeyType.php
+++ b/src/Form/Type/TagKeyType.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Algatux\InfluxDbBundle\Form\Type;
+
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Choice type listing available tag keys of a measurement.
+ */
+final class TagKeyType extends AbstractInfluxChoiceType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        parent::configureOptions($resolver);
+
+        $resolver
+            ->setRequired('measurement')
+            ->setDefaults([
+                'choices' => function (Options $options) {
+                    $choices = $this->loadChoicesFromQuery(
+                        sprintf('SHOW TAG KEYS FROM "%s"', $options['measurement']),
+                        'tagKey',
+                        $options['connection']
+                    );
+
+                    if ($options['exclude_host']) {
+                        unset($choices['host']);
+                    }
+
+                    return $choices;
+                },
+                // Set to false to include the host to the tag list.
+                'exclude_host' => true,
+            ])
+            ->setAllowedTypes('measurement', 'string')
+            ->setAllowedTypes('exclude_host', 'bool')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'influx_tag_key';
+    }
+}

--- a/src/Form/Type/TagValueType.php
+++ b/src/Form/Type/TagValueType.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Algatux\InfluxDbBundle\Form\Type;
+
+use Symfony\Component\OptionsResolver\Options;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Choice type listing available tag values of a measurement tag key.
+ */
+final class TagValueType extends AbstractInfluxChoiceType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        parent::configureOptions($resolver);
+
+        $resolver
+            ->setRequired(['measurement', 'tag_key'])
+            ->setDefaults([
+                'choices' => function (Options $options) {
+                    return $this->loadChoicesFromQuery(
+                        sprintf(
+                            'SHOW TAG VALUES FROM "%s" WITH KEY = "%s"',
+                            $options['measurement'],
+                            $options['tag_key']
+                        ),
+                        'value',
+                        $options['connection']
+                    );
+                },
+            ])
+            ->setAllowedTypes('measurement', ['string'])
+            ->setAllowedTypes('tag_key', ['string'])
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'influx_tag_value';
+    }
+}

--- a/src/Resources/config/form.xml
+++ b/src/Resources/config/form.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services
+        http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+
+        <service id="algatux_influx_db.form.type" class="Algatux\InfluxDbBundle\Form\Type\AbstractInfluxChoiceType"
+                 abstract="true">
+            <call method="setConnectionRegistry">
+                <argument type="service" id="algatux_influx_db.connection_registry" />
+            </call>
+        </service>
+
+        <service id="algatux_influx_db.form.type.field_key" class="Algatux\InfluxDbBundle\Form\Type\FieldKeyType"
+                 parent="algatux_influx_db.form.type">
+            <tag name="form.type" />
+        </service>
+
+        <service id="algatux_influx_db.form.type.measurement" class="Algatux\InfluxDbBundle\Form\Type\MeasurementType"
+                 parent="algatux_influx_db.form.type">
+            <tag name="form.type" />
+        </service>
+
+        <service id="algatux_influx_db.form.type.tag_key" class="Algatux\InfluxDbBundle\Form\Type\TagKeyType"
+                 parent="algatux_influx_db.form.type">
+            <tag name="form.type" />
+        </service>
+
+        <service id="algatux_influx_db.form.type.tag_value" class="Algatux\InfluxDbBundle\Form\Type\TagValueType"
+                 parent="algatux_influx_db.form.type">
+            <tag name="form.type" />
+        </service>
+
+    </services>
+</container>

--- a/src/Resources/config/registry.xml
+++ b/src/Resources/config/registry.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services
+        http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+
+        <service id="algatux_influx_db.connection_registry" class="Algatux\InfluxDbBundle\Services\ConnectionRegistry" />
+
+    </services>
+</container>

--- a/src/Services/ConnectionRegistry.php
+++ b/src/Services/ConnectionRegistry.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Algatux\InfluxDbBundle\Services;
+
+use Algatux\InfluxDbBundle\Exception\ConnectionNotFoundException;
+use InfluxDB\Database;
+
+/**
+ * Registry of all Database instances.
+ */
+final class ConnectionRegistry
+{
+    /**
+     * @var Database[]
+     */
+    private $connections = [];
+
+    /**
+     * @var string
+     */
+    private $defaultConnectionName;
+
+    /**
+     * @param string $defaultConnectionName
+     */
+    public function __construct($defaultConnectionName)
+    {
+        $this->defaultConnectionName = $defaultConnectionName;
+    }
+
+    /**
+     * @param string   $name
+     * @param string   $protocol
+     * @param Database $connection
+     */
+    public function addConnection(string $name, string $protocol, Database $connection)
+    {
+        if (!isset($this->connections[$name])) {
+            $this->connections[$name] = [];
+        }
+
+        $this->connections[$name][$protocol] = $connection;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return Database
+     */
+    public function getHttpConnection(string $name)
+    {
+        return $this->getConnection($name, 'http');
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return Database
+     */
+    public function getUdpConnection(string $name)
+    {
+        return $this->getConnection($name, 'udp');
+    }
+
+    /**
+     * @return Database
+     */
+    public function getDefaultHttpConnection()
+    {
+        return $this->getConnection($this->defaultConnectionName, 'http');
+    }
+
+    /**
+     * @return Database
+     */
+    public function getDefaultUdpConnection()
+    {
+        return $this->getConnection($this->defaultConnectionName, 'udp');
+    }
+
+    /**
+     * @param string $name
+     * @param string $protocol
+     *
+     * @return Database
+     *
+     * @throws ConnectionNotFoundException
+     */
+    private function getConnection(string $name, string $protocol)
+    {
+        if (!isset($this->connections[$name][$protocol])) {
+            throw new ConnectionNotFoundException($name, $protocol);
+        }
+
+        return $this->connections[$name][$protocol];
+    }
+}

--- a/tests/unit/Form/Type/AbstractInfluxChoiceTypeTest.php
+++ b/tests/unit/Form/Type/AbstractInfluxChoiceTypeTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Algatux\InfluxDbBundle\Tests\unit\Form\Type;
+
+use Algatux\InfluxDbBundle\Form\Type\AbstractInfluxChoiceType;
+use Algatux\InfluxDbBundle\Services\ConnectionRegistry;
+use InfluxDB\Database;
+use Symfony\Component\Form\PreloadedExtension;
+use Symfony\Component\Form\Test\TypeTestCase;
+
+abstract class AbstractInfluxChoiceTypeTest extends TypeTestCase
+{
+    /**
+     * @var Database|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $database;
+
+    /**
+     * @var ConnectionRegistry
+     */
+    private $connectionRegistry;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->database = $this->createMock(Database::class);
+
+        $this->connectionRegistry = new ConnectionRegistry('default');
+        $this->connectionRegistry->addConnection('default', 'http', $this->database);
+
+        parent::setUp();
+    }
+
+    protected function getExtensions()
+    {
+        $type = $this->getInfluxChoiceTypeInstance();
+        $type->setConnectionRegistry($this->connectionRegistry);
+
+        return [
+            new PreloadedExtension([$type], []),
+        ];
+    }
+
+    /**
+     * @return AbstractInfluxChoiceType
+     */
+    abstract protected function getInfluxChoiceTypeInstance();
+}

--- a/tests/unit/Form/Type/FieldKeyTypeTest.php
+++ b/tests/unit/Form/Type/FieldKeyTypeTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Algatux\InfluxDbBundle\Tests\unit\Form\Type;
+
+use Algatux\InfluxDbBundle\Form\Type\FieldKeyType;
+use InfluxDB\ResultSet;
+
+/**
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ */
+final class FieldKeyTypeTest extends AbstractInfluxChoiceTypeTest
+{
+    public function testSubmitValidData()
+    {
+        $formData = 'usage_guest';
+
+        $resultSet = new ResultSet(json_encode([
+            'results' => [
+                [
+                    'series' => [
+                        [
+                            'name' => 'cpu',
+                            'columns' => [
+                                'time',
+                                'fieldKey',
+                            ],
+                            'values' => [
+                                [
+                                    '1970-01-01T00:00:00Z',
+                                    'usage_guest',
+                                ],
+                                [
+                                    '1970-01-01T00:00:00Z',
+                                    'usage_idle',
+                                ],
+                                [
+                                    '1970-01-01T00:00:00Z',
+                                    'usage_nice',
+                                ],
+                                [
+                                    '1970-01-01T00:00:00Z',
+                                    'usage_iowait',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]));
+
+        $this->database->expects($this->once())->method('query')
+            ->with('SELECT fieldKey FROM "default"._fieldKeys WHERE _name = \'cpu\'')
+            ->willReturn($resultSet)
+        ;
+
+        $form = $this->factory->create(FieldKeyType::class, null, [
+            'measurement' => 'cpu',
+            'connection' => 'default',
+        ]);
+
+        // submit the data to the form directly
+        $form->submit($formData);
+
+        $this->assertTrue(
+            $form->isSynchronized(),
+            $form->getTransformationFailure()
+                ? $form->getTransformationFailure()->getMessage()
+                : 'The form should be synchronized'
+        );
+        $this->assertEquals($formData, $form->getData());
+
+        $view = $form->createView();
+        $this->assertCount(4, $view->vars['choices'], 'The form must have 4 choices');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getInfluxChoiceTypeInstance()
+    {
+        return new FieldKeyType();
+    }
+}

--- a/tests/unit/Form/Type/MeasurementTypeTest.php
+++ b/tests/unit/Form/Type/MeasurementTypeTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Algatux\InfluxDbBundle\Tests\unit\Form\Type;
+
+use Algatux\InfluxDbBundle\Form\Type\MeasurementType;
+use InfluxDB\ResultSet;
+
+/**
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ */
+final class MeasurementTypeTest extends AbstractInfluxChoiceTypeTest
+{
+    public function testSubmitValidData()
+    {
+        $formData = 'cpu';
+
+        $resultSet = new ResultSet(json_encode([
+            'results' => [
+                [
+                    'series' => [
+                        [
+                            'name' => 'measurement',
+                            'columns' => [
+                                'name',
+                            ],
+                            'values' => [
+                                [
+                                    'cpu',
+                                ],
+                                [
+                                    'mem',
+                                ],
+                                [
+                                    'disk',
+                                ],
+                                [
+                                    'apache',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]));
+
+        $this->database->expects($this->once())->method('query')
+            ->with('SHOW MEASUREMENTS')
+            ->willReturn($resultSet)
+        ;
+
+        $form = $this->factory->create(MeasurementType::class);
+
+        // submit the data to the form directly
+        $form->submit($formData);
+
+        $this->assertTrue(
+            $form->isSynchronized(),
+            $form->getTransformationFailure()
+                ? $form->getTransformationFailure()->getMessage()
+                : 'The form should be synchronized'
+        );
+        $this->assertEquals($formData, $form->getData());
+
+        $view = $form->createView();
+        $this->assertCount(4, $view->vars['choices'], 'The form must have 4 choices');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getInfluxChoiceTypeInstance()
+    {
+        return new MeasurementType();
+    }
+}

--- a/tests/unit/Form/Type/TagKeyTypeTest.php
+++ b/tests/unit/Form/Type/TagKeyTypeTest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Algatux\InfluxDbBundle\Tests\unit\Form\Type;
+
+use Algatux\InfluxDbBundle\Form\Type\TagKeyType;
+use InfluxDB\ResultSet;
+
+/**
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ */
+final class TagKeyTypeTest extends AbstractInfluxChoiceTypeTest
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $resultSet = new ResultSet(json_encode([
+            'results' => [
+                [
+                    'series' => [
+                        [
+                            'name' => 'cpu',
+                            'columns' => [
+                                'tagKey',
+                            ],
+                            'values' => [
+                                [
+                                    'cpu',
+                                ],
+                                [
+                                    'host',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]));
+
+        $this->database->expects($this->once())->method('query')
+            ->with('SHOW TAG KEYS FROM "cpu"')
+            ->willReturn($resultSet)
+        ;
+    }
+
+    public function testSubmitValidData()
+    {
+        $formData = 'cpu';
+
+        $form = $this->factory->create(TagKeyType::class, null, [
+            'measurement' => 'cpu',
+            'connection' => 'default',
+        ]);
+
+        // submit the data to the form directly
+        $form->submit($formData);
+
+        $this->assertTrue(
+            $form->isSynchronized(),
+            $form->getTransformationFailure()
+                ? $form->getTransformationFailure()->getMessage()
+                : 'The form should be synchronized'
+        );
+        $this->assertEquals($formData, $form->getData());
+
+        $view = $form->createView();
+        $this->assertCount(1, $view->vars['choices'], 'The form must have 1 choices');
+    }
+
+    public function testSubmitValidDataIncludingHost()
+    {
+        $formData = 'host';
+
+        $form = $this->factory->create(TagKeyType::class, null, [
+            'measurement' => 'cpu',
+            'connection' => 'default',
+            'exclude_host' => false,
+        ]);
+
+        // submit the data to the form directly
+        $form->submit($formData);
+
+        $this->assertTrue(
+            $form->isSynchronized(),
+            $form->getTransformationFailure()
+                ? $form->getTransformationFailure()->getMessage()
+                : 'The form should be synchronized'
+        );
+        $this->assertEquals($formData, $form->getData());
+
+        $view = $form->createView();
+        $this->assertCount(2, $view->vars['choices'], 'The form must have 2 choices');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getInfluxChoiceTypeInstance()
+    {
+        return new TagKeyType();
+    }
+}

--- a/tests/unit/Form/Type/TagValueTypeTest.php
+++ b/tests/unit/Form/Type/TagValueTypeTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Algatux\InfluxDbBundle\Tests\unit\Form\Type;
+
+use Algatux\InfluxDbBundle\Form\Type\TagValueType;
+use InfluxDB\ResultSet;
+
+/**
+ * @author Sullivan Senechal <soullivaneuh@gmail.com>
+ */
+final class TagValueTypeTest extends AbstractInfluxChoiceTypeTest
+{
+    public function testSubmitValidData()
+    {
+        $formData = 'aufs';
+
+        $resultSet = new ResultSet(json_encode([
+            'results' => [
+                [
+                    'series' => [
+                        [
+                            'name' => 'disk',
+                            'columns' => [
+                                'key',
+                                'value',
+                            ],
+                            'values' => [
+                                [
+                                    'fstype',
+                                    'ext4',
+                                ],
+                                [
+                                    'fstype',
+                                    'aufs',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]));
+
+        $this->database->expects($this->once())->method('query')
+            ->with('SHOW TAG VALUES FROM "disk" WITH KEY = "fstype"')
+            ->willReturn($resultSet)
+        ;
+
+        $form = $this->factory->create(TagValueType::class, null, [
+            'measurement' => 'disk',
+            'tag_key' => 'fstype',
+        ]);
+
+        // submit the data to the form directly
+        $form->submit($formData);
+
+        $this->assertTrue(
+            $form->isSynchronized(),
+            $form->getTransformationFailure()
+                ? $form->getTransformationFailure()->getMessage()
+                : 'The form should be synchronized'
+        );
+        $this->assertEquals($formData, $form->getData());
+
+        $view = $form->createView();
+        $this->assertCount(2, $view->vars['choices'], 'The form must have 2 choices');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getInfluxChoiceTypeInstance()
+    {
+        return new TagValueType();
+    }
+}


### PR DESCRIPTION
The goal of this PR is to add some useful form types.

The first commit is about the `ConnectionRegistry` class. This is needed to guess which connection to use.
- [x] Connections registry
- [x] `MeasurementType`: Measurement list
- [x] `TagKeyType`: Available keys list for a measurements
- [x] `TagValueType`: Available key vaues list for a measurements 
- [x] `FieldKeyType`: -> `SELECT fieldKey FROM telegraf_dev."default"._fieldKeys WHERE _name = 'measurement'`
- [x] Update and add the needed tests
- [x] Documentation for connection registry and form types

Those form types can be useful but are totally optional.

This is why the `symfony/form` package is suggested and not required.

If you have another idea of form type to add, feel free to comment! :+1: 

Regards.
