### PR TITLE
Remove upper conflict range with symfony/form

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "symfony/form": "Needed for form types usage"
     },
     "conflict": {
-        "symfony/form": "<2.8 || >=4.0"
+        "symfony/form": "<2.8"
     },
     "autoload": {
         "psr-4": { "Algatux\\InfluxDbBundle\\": "src/" }


### PR DESCRIPTION
Declaring a conflict with `symfony/form:>=4.0` is unneeded future proofness until 4.0 starts getting betas or release candidates that actually do conflict, and right now prohibit end users from installing `symfony/symfony:3.3-dev` as that declares a replacement on `symfony/form:dev-master`, which is by its definition higher than any stable version.

And as people like me want to test their own applications on the upcoming version of Symfony before it goes stable next month, that's highly unpractical.