### PR TITLE
Fix unit tests by explicitly setting PHPUnit version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,6 @@ before_install:
   - composer self-update
   - composer config --quiet --global github-oauth.github.com ${GITHUB_OAUTH_TOKEN}
   - composer require "satooshi/php-coveralls" --no-update
-  - composer require "phpunit/phpunit" --no-update
   - if [ "$SYMFONY" != "" ]; then composer require "symfony/symfony:${SYMFONY}" --no-update; fi;
 
 install:

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     },
     "require-dev": {
         "matthiasnoback/symfony-dependency-injection-test": "^1.0",
+        "phpunit/phpunit": "^5.6",
         "sllh/php-cs-fixer-styleci-bridge": "^2.0",
         "symfony/form": "^2.8 || ^3.0",
         "symfony/phpunit-bridge": "^3.1"


### PR DESCRIPTION
Was installed without version constraints in the travis.yml, causing conflicts with 6.0, and making local consistent testing unnecessarily hard.