### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": "^7.0",
-        "influxdb/influxdb-php": "^1.2",
+        "influxdata/influxdb-php": "^1.2",
         "symfony/console": "^2.8 || ^3.0 || ^4.0",
         "symfony/framework-bundle": "^2.8 || ^3.0 || ^4.0"
     },


### PR DESCRIPTION
InfluxDB organisation changed it's name to InfluxData so all the packages are there now. This is important for me to be able to temporarily use a fork of main client library with the bundle.