### PR TITLE
Set connection definition to be lazy

### DIFF
--- a/src/DependencyInjection/InfluxDbExtension.php
+++ b/src/DependencyInjection/InfluxDbExtension.php
@@ -66,6 +66,7 @@ final class InfluxDbExtension extends Extension
         ]);
         $connectionDefinition->setFactory([new Reference('algatux_influx_db.connection_factory'), 'createConnection']);
         $connectionDefinition->setPublic(true);
+        $connectionDefinition->setLazy(true);
 
         // E.g.: algatux_influx_db.connection.default.http
         $connectionServiceName = 'algatux_influx_db.connection.'.$connection.'.'.$protocol;


### PR DESCRIPTION
Having the connection be lazy allows to prebuild the container cache without having an Influxdb server available

Basically the same idea as https://github.com/snc/SncRedisBundle/pull/440