### PR TITLE
Configurable connection listener

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -71,6 +71,12 @@ influx_db:
             # Setup timeout or connection timeout (seconds) for your requests
             timeout:              0.0
             connect_timeout:      0.0
+            
+            # Set it to false to disable the event listener configuration
+            listener_enabled:     true
+
+            # Simple override for the default event listener class (constructor args and methods must match)
+            listener_class:       Algatux\InfluxDbBundle\Events\Listeners\InfluxDbEventListener
 ```
 
 If you have only one connection to configure, this can be simplified to this:
@@ -99,6 +105,12 @@ influx_db:
     # Setup timeout or connection timeout (seconds) for your requests
     timeout:              0.0
     connect_timeout:      0.0
+            
+    # Set it to false to disable the event listener configuration
+    listener_enabled:     true
+
+    # Simple override for the default event listener class (constructor args and methods must match)
+    listener_class:       Algatux\InfluxDbBundle\Events\Listeners\InfluxDbEventListener
 ```
 
 ### Services
@@ -233,6 +245,12 @@ $form
     ])
 ;
 ```
+
+### Custom event listeners
+
+In order to make it more flexible, you can override or even completely disable the default event listener and implement your own.
+
+It is useful i.e. if you want to add additional logging or error handling around the actual database calls.
 
 ### Contributing
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
     "require": {
         "php": "^7.0",
         "influxdb/influxdb-php": "^1.2",
-        "phpunit/phpunit": "^5.6",
         "symfony/console": "^2.8 || ^3.0 || ^4.0",
         "symfony/framework-bundle": "^2.8 || ^3.0 || ^4.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "require": {
         "php": "^7.0",
         "influxdb/influxdb-php": "^1.2",
+        "phpunit/phpunit": "^5.6",
         "symfony/console": "^2.8 || ^3.0 || ^4.0",
         "symfony/framework-bundle": "^2.8 || ^3.0 || ^4.0"
     },

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -2,6 +2,7 @@
 
 namespace Algatux\InfluxDbBundle\DependencyInjection;
 
+use Algatux\InfluxDbBundle\Events\Listeners\InfluxDbEventListener;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 
@@ -77,6 +78,14 @@ final class Configuration implements ConfigurationInterface
                             ->floatNode('connect_timeout')
                                 ->defaultValue(0.0)
                                 ->info('Setup connection timeout (seconds) for your requests')
+                            ->end()
+                            ->booleanNode('listener_enabled')
+                                ->defaultTrue()
+                                ->info('Set it to false to disable the event listener configuration')
+                            ->end()
+                            ->scalarNode('listener_class')
+                                ->defaultValue(InfluxDbEventListener::class)
+                                ->info('Simple override for the default event listener class (constructor args and methods must match)')
                             ->end()
                         ->end()
                     ->end()

--- a/src/DependencyInjection/InfluxDbExtension.php
+++ b/src/DependencyInjection/InfluxDbExtension.php
@@ -88,10 +88,15 @@ final class InfluxDbExtension extends Extension
     /**
      * @param ContainerBuilder $container
      * @param string           $connection
+     * @param array            $config
      * @param string           $defaultConnection
      */
-    private function createConnectionListener(ContainerBuilder $container, $connection, string $defaultConnection)
+    private function createConnectionListener(ContainerBuilder $container, $connection, array $config, string $defaultConnection)
     {
+        if (!$config['listener_enabled']) {
+            return;
+        }
+
         $listenerArguments = [
             $connection,
             $connection === $defaultConnection,
@@ -101,7 +106,7 @@ final class InfluxDbExtension extends Extension
             array_push($listenerArguments, new Reference('algatux_influx_db.connection.'.$connection.'.udp'));
         }
 
-        $listenerDefinition = new Definition(InfluxDbEventListener::class, $listenerArguments);
+        $listenerDefinition = new Definition($config['listener_class'], $listenerArguments);
         $listenerDefinition->addTag('kernel.event_listener', [
             'event' => 'influxdb.points_collected',
             'method' => 'onPointsCollected',
@@ -131,7 +136,7 @@ final class InfluxDbExtension extends Extension
                 $this->createConnection($container, $connection, $connectionConfig, self::PROTOCOL_UDP);
             }
 
-            $this->createConnectionListener($container, $connection, $defaultConnection);
+            $this->createConnectionListener($container, $connection, $connectionConfig, $defaultConnection);
         }
     }
 

--- a/src/DependencyInjection/InfluxDbExtension.php
+++ b/src/DependencyInjection/InfluxDbExtension.php
@@ -2,7 +2,6 @@
 
 namespace Algatux\InfluxDbBundle\DependencyInjection;
 
-use Algatux\InfluxDbBundle\Events\Listeners\InfluxDbEventListener;
 use InfluxDB\Database;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Alias;

--- a/tests/fixtures/config/config_multiple_connections.yml
+++ b/tests/fixtures/config/config_multiple_connections.yml
@@ -7,6 +7,20 @@ influx_db:
             username: foo
             password: bar
             timeout: 1
+        listener_disabled:
+            database: telegraf
+            host: localhost
+            username: foo
+            password: bar
+            timeout: 1
+            listener_enabled: false
+        listener_class_override:
+            database: telegraf
+            host: localhost
+            username: foo
+            password: bar
+            timeout: 1
+            listener_class: 'Acme\CustomInfluxDbEventListener'
         udp:
             database: test
             host: localhost

--- a/tests/unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/unit/DependencyInjection/ConfigurationTest.php
@@ -39,7 +39,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                     'timeout' => 0.0,
                     'connect_timeout' => 0.0,
                     'listener_enabled' => true,
-                    'listener_class' => InfluxDbEventListener::class
+                    'listener_class' => InfluxDbEventListener::class,
                 ],
             ],
         ];
@@ -66,7 +66,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                     'timeout' => 0.0,
                     'connect_timeout' => 0.0,
                     'listener_enabled' => true,
-                    'listener_class' => InfluxDbEventListener::class
+                    'listener_class' => InfluxDbEventListener::class,
                 ],
             ],
         ];
@@ -94,7 +94,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                     'timeout' => 1.5,
                     'connect_timeout' => 1,
                     'listener_enabled' => true,
-                    'listener_class' => InfluxDbEventListener::class
+                    'listener_class' => InfluxDbEventListener::class,
                 ],
             ],
         ];
@@ -122,7 +122,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                     'timeout' => 0.0,
                     'connect_timeout' => 0.0,
                     'listener_enabled' => true,
-                    'listener_class' => InfluxDbEventListener::class
+                    'listener_class' => InfluxDbEventListener::class,
                 ],
             ],
         ];
@@ -150,7 +150,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                     'timeout' => 1,
                     'connect_timeout' => 0.0,
                     'listener_enabled' => true,
-                    'listener_class' => InfluxDbEventListener::class
+                    'listener_class' => InfluxDbEventListener::class,
                 ],
                 'listener_disabled' => [
                     'database' => 'telegraf',
@@ -165,7 +165,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                     'timeout' => 1,
                     'connect_timeout' => 0.0,
                     'listener_enabled' => false,
-                    'listener_class' => InfluxDbEventListener::class
+                    'listener_class' => InfluxDbEventListener::class,
                 ],
                 'listener_class_override' => [
                     'database' => 'telegraf',
@@ -180,7 +180,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                     'timeout' => 1,
                     'connect_timeout' => 0.0,
                     'listener_enabled' => true,
-                    'listener_class' => 'Acme\CustomInfluxDbEventListener'
+                    'listener_class' => 'Acme\CustomInfluxDbEventListener',
                 ],
                 'udp' => [
                     'database' => 'test',
@@ -195,7 +195,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                     'timeout' => 0.0,
                     'connect_timeout' => 1,
                     'listener_enabled' => true,
-                    'listener_class' => InfluxDbEventListener::class
+                    'listener_class' => InfluxDbEventListener::class,
                 ],
                 'ssl' => [
                     'database' => 'test',
@@ -210,7 +210,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                     'timeout' => 0.0,
                     'connect_timeout' => 0.0,
                     'listener_enabled' => true,
-                    'listener_class' => InfluxDbEventListener::class
+                    'listener_class' => InfluxDbEventListener::class,
                 ],
                 'ssl_no_check' => [
                     'database' => 'test',
@@ -225,7 +225,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                     'timeout' => 0.0,
                     'connect_timeout' => 1,
                     'listener_enabled' => true,
-                    'listener_class' => InfluxDbEventListener::class
+                    'listener_class' => InfluxDbEventListener::class,
                 ],
             ],
         ];

--- a/tests/unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/unit/DependencyInjection/ConfigurationTest.php
@@ -6,6 +6,7 @@ namespace Algatux\InfluxDbBundle\Tests\unit;
 
 use Algatux\InfluxDbBundle\DependencyInjection\Configuration;
 use Algatux\InfluxDbBundle\DependencyInjection\InfluxDbExtension;
+use Algatux\InfluxDbBundle\Events\Listeners\InfluxDbEventListener;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionConfigurationTestCase;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
@@ -37,6 +38,8 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                     'password' => '',
                     'timeout' => 0.0,
                     'connect_timeout' => 0.0,
+                    'listener_enabled' => true,
+                    'listener_class' => InfluxDbEventListener::class
                 ],
             ],
         ];
@@ -62,6 +65,8 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                     'password' => '',
                     'timeout' => 0.0,
                     'connect_timeout' => 0.0,
+                    'listener_enabled' => true,
+                    'listener_class' => InfluxDbEventListener::class
                 ],
             ],
         ];
@@ -88,6 +93,8 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                     'password' => 'bar',
                     'timeout' => 1.5,
                     'connect_timeout' => 1,
+                    'listener_enabled' => true,
+                    'listener_class' => InfluxDbEventListener::class
                 ],
             ],
         ];
@@ -114,6 +121,8 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                     'password' => 'bar',
                     'timeout' => 0.0,
                     'connect_timeout' => 0.0,
+                    'listener_enabled' => true,
+                    'listener_class' => InfluxDbEventListener::class
                 ],
             ],
         ];
@@ -140,6 +149,38 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                     'password' => 'bar',
                     'timeout' => 1,
                     'connect_timeout' => 0.0,
+                    'listener_enabled' => true,
+                    'listener_class' => InfluxDbEventListener::class
+                ],
+                'listener_disabled' => [
+                    'database' => 'telegraf',
+                    'host' => 'localhost',
+                    'udp' => false,
+                    'ssl' => false,
+                    'ssl_verification' => false,
+                    'udp_port' => 4444,
+                    'http_port' => 8086,
+                    'username' => 'foo',
+                    'password' => 'bar',
+                    'timeout' => 1,
+                    'connect_timeout' => 0.0,
+                    'listener_enabled' => false,
+                    'listener_class' => InfluxDbEventListener::class
+                ],
+                'listener_class_override' => [
+                    'database' => 'telegraf',
+                    'host' => 'localhost',
+                    'udp' => false,
+                    'ssl' => false,
+                    'ssl_verification' => false,
+                    'udp_port' => 4444,
+                    'http_port' => 8086,
+                    'username' => 'foo',
+                    'password' => 'bar',
+                    'timeout' => 1,
+                    'connect_timeout' => 0.0,
+                    'listener_enabled' => true,
+                    'listener_class' => 'Acme\CustomInfluxDbEventListener'
                 ],
                 'udp' => [
                     'database' => 'test',
@@ -153,6 +194,8 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                     'password' => 'bar',
                     'timeout' => 0.0,
                     'connect_timeout' => 1,
+                    'listener_enabled' => true,
+                    'listener_class' => InfluxDbEventListener::class
                 ],
                 'ssl' => [
                     'database' => 'test',
@@ -166,6 +209,8 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                     'password' => 'bar',
                     'timeout' => 0.0,
                     'connect_timeout' => 0.0,
+                    'listener_enabled' => true,
+                    'listener_class' => InfluxDbEventListener::class
                 ],
                 'ssl_no_check' => [
                     'database' => 'test',
@@ -179,6 +224,8 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                     'password' => 'bar',
                     'timeout' => 0.0,
                     'connect_timeout' => 1,
+                    'listener_enabled' => true,
+                    'listener_class' => InfluxDbEventListener::class
                 ],
             ],
         ];


### PR DESCRIPTION
I added some configuration options for the event listener.
With the default settings it will just work as before, so there is no BC-break.

In my use-case I wanted to add some error handling and logging around the actual db calls, that's why I wanted to add my custom event listener and disable the bundled one.

I also added tests and some lines to the readme.

Please consider merging it if you find it useful.

And of course, thanks for your work! :)
