### PR TITLE
Drop Symfony 2.8 support, add Symfony 5 support, set PHP requirements to ^7.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 /vendor/
 /bin/
 /.php_cs.cache
+/.phpunit.result.cache
 /data/
 /meta/

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,9 @@ cache:
 
 before_install:
   - composer self-update
-  -  if [ "$GITHUB_OAUTH_TOKEN" != "" ]; then composer config --quiet --global github-oauth.github.com ${GITHUB_OAUTH_TOKEN}; fi;
-  - composer require "satooshi/php-coveralls" --no-update
+  - if [ "$GITHUB_OAUTH_TOKEN" != "" ]; then composer config --quiet --global github-oauth.github.com ${GITHUB_OAUTH_TOKEN}; fi;
   - if [ "$SYMFONY" != "" ]; then composer require "symfony/symfony:${SYMFONY}" --no-update; fi;
+  - composer require "php-coveralls/php-coveralls" --no-update
 
 install:
   - mkdir --parents "${HOME}/bin"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: '7.0'
-    - php: '7.0'
+    - php: '7.1'
+    - php: '7.1'
       env: COMPOSER_FLAGS="--prefer-lowest"
     - php: '7.1'
       env: SYMFONY=3.4.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,12 @@ matrix:
       env: SYMFONY=4.0.*
     - php: '7.3'
       env: SYMFONY=4.0.*
+    - php: '7.1'
+      env: SYMFONY=5.0.*
+    - php: '7.2'
+      env: SYMFONY=5.0.*
+    - php: '7.3'
+      env: SYMFONY=5.0.*
     - php: '7.3'
       env: SYMFONY=dev-master
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ matrix:
     - php: '7.0'
     - php: '7.0'
       env: COMPOSER_FLAGS="--prefer-lowest"
-    - php: '7.0'
-      env: SYMFONY=2.8.*
     - php: '7.1'
       env: SYMFONY=3.4.*
     - php: '7.1'

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,6 @@ before_install:
   - composer self-update
   -  if [ "$GITHUB_OAUTH_TOKEN" != "" ]; then composer config --quiet --global github-oauth.github.com ${GITHUB_OAUTH_TOKEN}; fi;
   - composer require "satooshi/php-coveralls" --no-update
-  - composer require "phpunit/phpunit:^5.6" --no-update
   - if [ "$SYMFONY" != "" ]; then composer require "symfony/symfony:${SYMFONY}" --no-update; fi;
 
 install:
@@ -47,13 +46,14 @@ install:
   - wget https://scrutinizer-ci.com/ocular.phar --output-document="${HOME}/bin/ocular" && chmod +x "${HOME}/bin/ocular"
   - composer global require --prefer-dist --no-interaction sllh/composer-lint:@stable
   - composer update --prefer-dist --no-interaction ${COMPOSER_FLAGS}
+  - vendor/bin/simple-phpunit install
 
 before_script:
   - echo "zend_extension=xdebug.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 
 script:
   - composer validate
-  - vendor/bin/phpunit -c . --coverage-clover=./build/coverage/coverage.xml
+  - vendor/bin/simple-phpunit --coverage-clover=./build/coverage/coverage.xml
 
 after_success:
   - ocular code-coverage:upload --format=php-clover ./build/coverage/coverage.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,27 +8,27 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: '7.1'
-    - php: '7.1'
+    - php: '7.2'
+    - php: '7.2'
       env: COMPOSER_FLAGS="--prefer-lowest"
-    - php: '7.1'
+    - php: '7.2'
       env: SYMFONY=3.4.*
-    - php: '7.1'
-      env: SYMFONY=4.0.*
     - php: '7.2'
       env: SYMFONY=4.0.*
     - php: '7.3'
       env: SYMFONY=4.0.*
-    - php: '7.1'
-      env: SYMFONY=5.0.*
+    - php: '7.4'
+      env: SYMFONY=4.0.*
     - php: '7.2'
       env: SYMFONY=5.0.*
     - php: '7.3'
       env: SYMFONY=5.0.*
-    - php: '7.3'
+    - php: '7.4'
+      env: SYMFONY=5.0.*
+    - php: '7.4'
       env: SYMFONY=dev-master
   allow_failures:
-    - php: '7.3'
+    - php: '7.4'
     - env: SYMFONY=dev-master
 
 cache:

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
         "phpspec/prophecy": "^1.10",
         "symfony/form": "^3.4 || ^4.0 || ^5.0",
-        "symfony/phpunit-bridge": "^4.0 || ^5.0"
+        "symfony/phpunit-bridge": "^3.4 || ^4.0 || ^5.0"
     },
     "suggest": {
         "symfony/form": "Needed for form types usage",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.0",
+        "php": "^7.1",
         "influxdb/influxdb-php": "^1.2",
         "symfony/console": "^3.4 || ^4.0 || ^5.0",
         "symfony/framework-bundle": "^3.4 || ^4.0 || ^5.0"

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "symfony/framework-bundle": "^2.8 || ^3.0 || ^4.0 || ^5.0"
     },
     "require-dev": {
-        "matthiasnoback/symfony-dependency-injection-test": "^1.0",
+        "matthiasnoback/symfony-dependency-injection-test": "^4.1",
+        "phpspec/prophecy": "~1.0",
         "symfony/form": "^2.8 || ^3.0 || ^4.0 || ^5.0",
         "symfony/phpunit-bridge": "^4.0 || ^5.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,13 @@
     "require": {
         "php": "^7.0",
         "influxdb/influxdb-php": "^1.2",
-        "symfony/console": "^2.8 || ^3.0 || ^4.0 || ^5.0",
-        "symfony/framework-bundle": "^2.8 || ^3.0 || ^4.0 || ^5.0"
+        "symfony/console": "^3.4 || ^4.0 || ^5.0",
+        "symfony/framework-bundle": "^3.4 || ^4.0 || ^5.0"
     },
     "require-dev": {
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
         "phpspec/prophecy": "~1.0",
-        "symfony/form": "^2.8 || ^3.0 || ^4.0 || ^5.0",
+        "symfony/form": "^3.4 || ^4.0 || ^5.0",
         "symfony/phpunit-bridge": "^4.0 || ^5.0"
     },
     "suggest": {
@@ -31,7 +31,7 @@
         "symfony/proxy-manager-bridge": "Needed to lazy-load connection services"
     },
     "conflict": {
-        "symfony/form": "<2.8"
+        "symfony/form": "<3.4"
     },
     "autoload": {
         "psr-4": { "Algatux\\InfluxDbBundle\\": "src/" }

--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,13 @@
     "require": {
         "php": "^7.0",
         "influxdb/influxdb-php": "^1.2",
-        "symfony/console": "^2.8 || ^3.0 || ^4.0",
-        "symfony/framework-bundle": "^2.8 || ^3.0 || ^4.0"
+        "symfony/console": "^2.8 || ^3.0 || ^4.0 || ^5.0",
+        "symfony/framework-bundle": "^2.8 || ^3.0 || ^4.0 || ^5.0"
     },
     "require-dev": {
         "matthiasnoback/symfony-dependency-injection-test": "^1.0",
-        "symfony/form": "^2.8 || ^3.0 || ^4.0",
-        "symfony/phpunit-bridge": "^4.0"
+        "symfony/form": "^2.8 || ^3.0 || ^4.0 || ^5.0",
+        "symfony/phpunit-bridge": "^4.0 || ^5.0"
     },
     "suggest": {
         "symfony/form": "Needed for form types usage",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
         "influxdb/influxdb-php": "^1.2",
         "symfony/console": "^3.4 || ^4.0 || ^5.0",
         "symfony/framework-bundle": "^3.4 || ^4.0 || ^5.0"

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
-        "phpspec/prophecy": "~1.0",
+        "phpspec/prophecy": "^1.10",
         "symfony/form": "^3.4 || ^4.0 || ^5.0",
         "symfony/phpunit-bridge": "^4.0 || ^5.0"
     },

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -5,15 +5,21 @@ declare(strict_types=1);
 namespace Algatux\InfluxDbBundle\Command;
 
 use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Base class for InfluxDbBundle commands.
  */
-abstract class AbstractCommand extends ContainerAwareCommand
+abstract class AbstractCommand extends Command implements ContainerAwareInterface
 {
+    use ContainerAwareTrait;
+
     /**
      * @var SymfonyStyle
      */
@@ -25,5 +31,13 @@ abstract class AbstractCommand extends ContainerAwareCommand
     protected function initialize(InputInterface $input, OutputInterface $output)
     {
         $this->io = new SymfonyStyle($input, $output);
+    }
+
+    /**
+     * @return ContainerInterface
+     */
+    public function getContainer(): ContainerInterface
+    {
+        return $this->container;
     }
 }

--- a/src/Command/AbstractCommand.php
+++ b/src/Command/AbstractCommand.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Algatux\InfluxDbBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -18,8 +18,13 @@ final class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('influx_db');
+        if (method_exists(TreeBuilder::class, 'getRootNode')) {
+            $treeBuilder = new TreeBuilder('influx_db');
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            $treeBuilder = new TreeBuilder();
+            $rootNode = $treeBuilder->root('influx_db');
+        }
 
         $rootNode
             ->beforeNormalization()

--- a/src/Events/AbstractInfluxDbEvent.php
+++ b/src/Events/AbstractInfluxDbEvent.php
@@ -5,12 +5,11 @@ declare(strict_types=1);
 namespace Algatux\InfluxDbBundle\Events;
 
 use InfluxDB\Point;
-use Symfony\Component\EventDispatcher\Event;
 
 /**
  * Class AbstractInfluxDbEvent.
  */
-abstract class AbstractInfluxDbEvent extends Event
+abstract class AbstractInfluxDbEvent extends SymfonyEvent
 {
     const NAME = 'influxdb.points_collected';
 

--- a/src/Events/SymfonyEvent.php
+++ b/src/Events/SymfonyEvent.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Algatux\InfluxDbBundle\Events;
+
+// Symfony 5+
+if (class_exists('\Symfony\Contracts\EventDispatcher\Event')) {
+    class SymfonyEvent extends \Symfony\Contracts\EventDispatcher\Event
+    {
+    }
+} else {
+    class SymfonyEvent extends \Symfony\Component\EventDispatcher\Event
+    {
+    }
+}
+

--- a/src/Events/SymfonyEvent.php
+++ b/src/Events/SymfonyEvent.php
@@ -12,4 +12,3 @@ if (class_exists('\Symfony\Contracts\EventDispatcher\Event')) {
     {
     }
 }
-

--- a/tests/unit/Command/CreateDatabaseCommandTest.php
+++ b/tests/unit/Command/CreateDatabaseCommandTest.php
@@ -6,11 +6,12 @@ namespace Algatux\InfluxDbBundle\Tests\unit\Command;
 
 use Algatux\InfluxDbBundle\Command\CreateDatabaseCommand;
 use InfluxDB\Database;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-final class CreateDatabaseCommandTest extends \PHPUnit_Framework_TestCase
+final class CreateDatabaseCommandTest extends TestCase
 {
     public function test_execute()
     {

--- a/tests/unit/Command/DropDatabaseCommandTest.php
+++ b/tests/unit/Command/DropDatabaseCommandTest.php
@@ -6,11 +6,12 @@ namespace Algatux\InfluxDbBundle\Tests\unit\Command;
 
 use Algatux\InfluxDbBundle\Command\DropDatabaseCommand;
 use InfluxDB\Database;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-final class DropDatabaseCommandTest extends \PHPUnit_Framework_TestCase
+final class DropDatabaseCommandTest extends TestCase
 {
     public function test_execute()
     {

--- a/tests/unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/unit/DependencyInjection/ConfigurationTest.php
@@ -8,7 +8,9 @@ use Algatux\InfluxDbBundle\DependencyInjection\Configuration;
 use Algatux\InfluxDbBundle\DependencyInjection\InfluxDbExtension;
 use Algatux\InfluxDbBundle\Events\Listeners\InfluxDbEventListener;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionConfigurationTestCase;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 
 class ConfigurationTest extends AbstractExtensionConfigurationTestCase
 {
@@ -238,7 +240,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getContainerExtension()
+    protected function getContainerExtension(): ExtensionInterface
     {
         return new InfluxDbExtension();
     }
@@ -246,7 +248,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getConfiguration()
+    protected function getConfiguration(): ConfigurationInterface
     {
         return new Configuration();
     }

--- a/tests/unit/DependencyInjection/InfluxDbExtensionTest.php
+++ b/tests/unit/DependencyInjection/InfluxDbExtensionTest.php
@@ -200,7 +200,7 @@ class InfluxDbExtensionTest extends AbstractExtensionTestCase
     /**
      * {@inheritdoc}
      */
-    protected function getContainerExtensions()
+    protected function getContainerExtensions(): array
     {
         return [
             new InfluxDbExtension(),

--- a/tests/unit/Events/InfluxDbEventTest.php
+++ b/tests/unit/Events/InfluxDbEventTest.php
@@ -7,8 +7,9 @@ namespace Algatux\InfluxDbBundle\unit\Events;
 use Algatux\InfluxDbBundle\Events\AbstractInfluxDbEvent;
 use Algatux\InfluxDbBundle\Events\HttpEvent;
 use InfluxDB\Database;
+use PHPUnit\Framework\TestCase;
 
-class InfluxDbEventTest extends \PHPUnit_Framework_TestCase
+class InfluxDbEventTest extends TestCase
 {
     /**
      * @group legacy

--- a/tests/unit/Events/Listeners/InfluxDbEventListenerTest.php
+++ b/tests/unit/Events/Listeners/InfluxDbEventListenerTest.php
@@ -10,10 +10,11 @@ use Algatux\InfluxDbBundle\Events\HttpEvent;
 use Algatux\InfluxDbBundle\Events\Listeners\InfluxDbEventListener;
 use Algatux\InfluxDbBundle\Events\UdpEvent;
 use InfluxDB\Database;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Symfony\Component\EventDispatcher\Event;
 
-class InfluxDbEventListenerTest extends \PHPUnit_Framework_TestCase
+class InfluxDbEventListenerTest extends TestCase
 {
     public function test_listening_for_udp_infuxdb_event()
     {

--- a/tests/unit/Events/Listeners/InfluxDbEventListenerTest.php
+++ b/tests/unit/Events/Listeners/InfluxDbEventListenerTest.php
@@ -8,11 +8,11 @@ use Algatux\InfluxDbBundle\Events\DeferredHttpEvent;
 use Algatux\InfluxDbBundle\Events\DeferredUdpEvent;
 use Algatux\InfluxDbBundle\Events\HttpEvent;
 use Algatux\InfluxDbBundle\Events\Listeners\InfluxDbEventListener;
+use Algatux\InfluxDbBundle\Events\SymfonyEvent;
 use Algatux\InfluxDbBundle\Events\UdpEvent;
 use InfluxDB\Database;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
-use Symfony\Component\EventDispatcher\Event;
 
 class InfluxDbEventListenerTest extends TestCase
 {
@@ -86,7 +86,7 @@ class InfluxDbEventListenerTest extends TestCase
         $listener->onPointsCollected($event2);
         $listener->onPointsCollected($event3);
 
-        $listener->onKernelTerminate(new Event());
+        $listener->onKernelTerminate(new SymfonyEvent());
     }
 
     public function test_listening_for_deferred_http_infuxdb_event()
@@ -109,7 +109,7 @@ class InfluxDbEventListenerTest extends TestCase
         $listener->onPointsCollected($event2);
         $listener->onPointsCollected($event3);
 
-        $listener->onKernelTerminate(new Event());
+        $listener->onKernelTerminate(new SymfonyEvent());
     }
 
     public function test_listening_for_deferred_http_infuxdb_event_from_console()
@@ -132,7 +132,7 @@ class InfluxDbEventListenerTest extends TestCase
         $listener->onPointsCollected($event2);
         $listener->onPointsCollected($event3);
 
-        $listener->onConsoleTerminate(new Event());
+        $listener->onConsoleTerminate(new SymfonyEvent());
     }
 
     public function test_not_available_deferred_udp_infuxdb_event()

--- a/tests/unit/Form/Type/AbstractInfluxChoiceTypeTest.php
+++ b/tests/unit/Form/Type/AbstractInfluxChoiceTypeTest.php
@@ -11,7 +11,7 @@ use Symfony\Component\Form\Test\TypeTestCase;
 abstract class AbstractInfluxChoiceTypeTest extends TypeTestCase
 {
     /**
-     * @var Database|\PHPUnit_Framework_MockObject_MockObject
+     * @var Database|\PHPUnit\Framework\MockObject\MockObject
      */
     protected $database;
 
@@ -23,7 +23,7 @@ abstract class AbstractInfluxChoiceTypeTest extends TypeTestCase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->database = $this->createMock(Database::class);
 

--- a/tests/unit/Form/Type/TagKeyTypeTest.php
+++ b/tests/unit/Form/Type/TagKeyTypeTest.php
@@ -10,7 +10,7 @@ use InfluxDB\ResultSet;
  */
 final class TagKeyTypeTest extends AbstractInfluxChoiceTypeTest
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/unit/InfluxDbBundleTest.php
+++ b/tests/unit/InfluxDbBundleTest.php
@@ -16,7 +16,7 @@ class InfluxDbBundleTest extends AbstractContainerBuilderTestCase
      */
     protected $bundle;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
This PR is a proposal for Symfony 5.0 support.

Also, I've seen issue #89 and #88 while working on this PR. I think it's ok to drop support of Symfony 2.8 and up PHP requirements to PHP 7.1 here, but I can remove those commits if needed. :+1: 

**EDIT:** we have some issues on Travis:
- `matthiasnoback/symfony-dependency-injection-test` 4.1.0 is required for Symfony 5 support, but it requires PHP 7.2 (https://travis-ci.org/Algatux/influxdb-bundle/jobs/648326614, https://travis-ci.org/Algatux/influxdb-bundle/jobs/648326615, https://travis-ci.org/Algatux/influxdb-bundle/jobs/648326616, https://travis-ci.org/Algatux/influxdb-bundle/jobs/648326617)
- `phpunit/phpunit` is not installable due to conflicts with `matthiasnoback/symfony-dependency-injection-test` and `matthiasnoback/symfony-config-test` (https://travis-ci.org/Algatux/influxdb-bundle/jobs/648326618, https://travis-ci.org/Algatux/influxdb-bundle/jobs/648326619, https://travis-ci.org/Algatux/influxdb-bundle/jobs/648326620)

What do you think of: 
- remove `matthiasnoback/symfony-dependency-injection-test`
- remove the `composer require "phpunit/phpunit:^5.6" --no-update` line, which I think is useless since `symfony/phpunit-bridge` alreayd install PHPUnit
- use [`nyholm/symfony-bundle-test`](https://packagist.org/packages/nyholm/symfony-bundle-test) which:
  - requires php ^5.5 or ^7.0
  - does not require or conflict with `phpunit/phpunit`
  - have support for Symfony ^3.4, ^4.3 and ^5.0
  - but will require a lot of work

Another solution is to set PHP requirement to ^7.2 which is still maintained unlike 7.1: https://www.php.net/supported-versions.php 
