### PR TITLE
chore(ci): Make the CI happy

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -2,4 +2,3 @@ preset: symfony
 
 enabled:
   - ordered_use
-  - short_array_syntax

--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,6 +1,5 @@
 preset: symfony
 
 enabled:
-  - newline_after_open_tag
   - ordered_use
   - short_array_syntax

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,21 +12,21 @@ matrix:
     - php: '7.2'
       env: COMPOSER_FLAGS="--prefer-lowest"
     - php: '7.2'
-      env: SYMFONY=3.4.*
+      env: SYMFONY_REQUIRE=3.4.*
     - php: '7.2'
-      env: SYMFONY=4.0.*
+      env: SYMFONY_REQUIRE=4.0.*
     - php: '7.3'
-      env: SYMFONY=4.0.*
+      env: SYMFONY_REQUIRE=4.0.*
     - php: '7.4'
-      env: SYMFONY=4.0.*
+      env: SYMFONY_REQUIRE=4.0.*
     - php: '7.2'
-      env: SYMFONY=5.0.*
+      env: SYMFONY_REQUIRE=5.0.*
     - php: '7.3'
-      env: SYMFONY=5.0.*
+      env: SYMFONY_REQUIRE=5.0.*
     - php: '7.4'
-      env: SYMFONY=5.0.*
+      env: SYMFONY_REQUIRE=5.0.*
     - php: '7.4'
-      env: SYMFONY=dev-master
+      env: SYMFONY_REQUIRE=dev-master
   allow_failures:
     - php: '7.4'
     - env: SYMFONY=dev-master
@@ -38,7 +38,7 @@ cache:
 before_install:
   - composer self-update
   - if [ "$GITHUB_OAUTH_TOKEN" != "" ]; then composer config --quiet --global github-oauth.github.com ${GITHUB_OAUTH_TOKEN}; fi;
-  - if [ "$SYMFONY" != "" ]; then composer require "symfony/symfony:${SYMFONY}" --no-update; fi;
+  - composer global require --no-progress --no-scripts --no-plugins symfony/flex dev-main
   - composer require "php-coveralls/php-coveralls" --no-update
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,17 +14,23 @@ matrix:
     - php: '7.2'
       env: SYMFONY_REQUIRE=3.4.*
     - php: '7.2'
-      env: SYMFONY_REQUIRE=4.0.*
+      env: SYMFONY_REQUIRE=4.4.*
     - php: '7.3'
-      env: SYMFONY_REQUIRE=4.0.*
+      env: SYMFONY_REQUIRE=4.4.*
     - php: '7.4'
-      env: SYMFONY_REQUIRE=4.0.*
+      env: SYMFONY_REQUIRE=4.4.*
     - php: '7.2'
       env: SYMFONY_REQUIRE=5.0.*
     - php: '7.3'
       env: SYMFONY_REQUIRE=5.0.*
     - php: '7.4'
       env: SYMFONY_REQUIRE=5.0.*
+    - php: '7.2'
+      env: SYMFONY_REQUIRE=5.1.*
+    - php: '7.3'
+      env: SYMFONY_REQUIRE=5.1.*
+    - php: '7.4'
+      env: SYMFONY_REQUIRE=5.1.*
     - php: '7.4'
       env: SYMFONY_REQUIRE=dev-master
   allow_failures:


### PR DESCRIPTION
Using `SYMFONY_REQUIRE` and `symfony/flex` for specifying the Symfony version to use, see https://github.com/symfony/flex/pull/409. We gain ~10 secs during the `composer update` (https://travis-ci.org/github/Algatux/influxdb-bundle/builds/671260308 vs https://travis-ci.org/github/Algatux/influxdb-bundle/builds/740050252)